### PR TITLE
Run all accuracy tasks in parallel

### DIFF
--- a/.github/workflows/validate_accuracy.yml
+++ b/.github/workflows/validate_accuracy.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         ruby: [3.4.1]
-        kernel: [de405, de421, de430t, de440s]
-        target: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        kernel: [de440s]
+        target: [3]
 
     steps:
       - uses: actions/checkout@v4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ PLATFORMS
 DEPENDENCIES
   csv (~> 3.3)
   ephem!
+  parallel (~> 1.26)
   rake (~> 13.0)
   rspec (~> 3.13)
   standard (~> 1.43)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,44 @@ puts "Velocity: #{state.velocity}"
 # The velocity is expressed in km/day
 ```
 
+## Accuracy
+
+Data from this library has been tested against the Python library [jplephem]
+by Brandon Rhodes.
+
+The following kernels have been used:
+* DE405
+* DE421
+* DE430t
+* DE440s
+
+The times tested are noon UTC for every day between 2000-01-01 and
+2050-01-01. Vectors tested are always with `center` 0 (Solar System Barycenter),
+and `target` from `1` (Mercury Barycenter) to `10` (Sun).
+
+Rake tasks ensure data from this library match with `jplephem` with a margin
+error of 2 centimeters.
+
+You can run them by following this pattern:
+
+```
+rake validate_accuracy date=2000 kernel=de440s target=1
+```
+
+_Note: Only date=2000 is supported at the moment. It covers 2000 to 2050._
+
+If you wish to test them all in parallel, you can run:
+
+```
+rake validate_accuracy:all
+```
+
+For every commit, one test is executed in CI to ensure quality and accuracy
+is always respected. At the moment, we don't run them all in CI to save
+usage time.
+
+[jplephem]: https://pypi.org/project/jplephem/
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run
@@ -97,16 +135,18 @@ interactive prompt that will allow you to experiment.
 Bug reports and pull requests are welcome on GitHub at
 https://github.com/rhannequin/ruby-ephem. This project is intended to be a
 safe, welcoming space for collaboration, and contributors are expected to adhere
-to
-the [code of conduct](https://github.com/rhannequin/ephem/blob/main/CODE_OF_CONDUCT.md).
+to the [code of conduct].
 
 ## License
 
-The gem is available as open source under the terms of
-the [MIT License](https://opensource.org/licenses/MIT).
+The gem is available as open source under the terms of the [MIT License].
+
+[MIT License]: (https://opensource.org/licenses/MIT)
 
 ## Code of Conduct
 
 Everyone interacting in the Ephem project's codebases, issue trackers, chat
 rooms and mailing lists is expected to follow
-the [code of conduct](https://github.com/rhannequin/ephem/blob/main/CODE_OF_CONDUCT.md).
+the [code of conduct].
+
+[code of conduct]: (https://github.com/rhannequin/ephem/blob/main/CODE_OF_CONDUCT.md)

--- a/ephem.gemspec
+++ b/ephem.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "numo-narray", "~> 0.9.2.1"
 
   spec.add_development_dependency "csv", "~> 3.3"
+  spec.add_development_dependency "parallel", "~> 1.26"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.13"
   spec.add_development_dependency "standard", "~> 1.43"

--- a/lib/ephem/tasks/validate_accuracy.rb
+++ b/lib/ephem/tasks/validate_accuracy.rb
@@ -25,12 +25,16 @@ module Ephem
       end
 
       def run(date:, kernel:, target:)
+        @start_time = Time.now
         @start_date = date
         @kernel_name = kernel
         @target = target.to_i
 
         perform_task
-        puts "#{validations_count} validation passed."
+        @end_time = Time.now
+
+        puts output
+
         true
       rescue ValidationError => e
         puts "Error occurred: #{e.message}"
@@ -97,6 +101,12 @@ module Ephem
 
       def kernels
         @kernels ||= {}
+      end
+
+      def output
+        duration = (@end_time - @start_time).to_i
+        title = "#{@kernel_name}/2000-2050/#{@target}"
+        "#{validations_count} validation passed (#{title}) in #{duration} seconds."
       end
     end
   end

--- a/lib/tasks/validate_accuracy.rake
+++ b/lib/tasks/validate_accuracy.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "parallel"
+
 require_relative "../ephem/tasks/validate_accuracy"
 
 desc "
@@ -13,7 +15,7 @@ task :validate_accuracy do
 
   unless date && kernel && target
     puts "Error: All parameters are required"
-    puts "Usage: rake validate_accuracy date=1900 kernel=de440 target=1"
+    puts "Usage: rake validate_accuracy date=2000 kernel=de440s target=1"
     exit 1
   end
 
@@ -23,4 +25,23 @@ task :validate_accuracy do
   end
 end
 
-desc "Run validation accuracy checks. "
+namespace :validate_accuracy do
+  task :all do
+    kernels = Ephem::Tasks::ValidateAccuracy::KERNELS.keys
+    targets = (1..10).to_a.map(&:to_s)
+
+    parameter_sets = kernels.product(targets).map do |kernel, target|
+      {date: "2000", kernel: kernel, target: target}
+    end
+
+    results = Parallel.map(parameter_sets, in_processes: 10) do |params|
+      Ephem::Tasks::ValidateAccuracy.run(
+        date: params[:date],
+        kernel: params[:kernel],
+        target: params[:target]
+      )
+    end
+
+    exit 1 if results.any?(FalseClass)
+  end
+end


### PR DESCRIPTION
This enables a new rake task `validate_accuracy:all` to run all accuracy tasks in parallel.

It also stops running them all in CI to save usage time.