### PR TITLE
Spk excerpt generator

### DIFF
--- a/bin/ruby-ephem
+++ b/bin/ruby-ephem
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Add the lib directory to the load path
+lib = File.expand_path("../lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require "ephem"
+require "ephem/cli"
+
+# Run the CLI
+Ephem::CLI.start(ARGV)

--- a/ephem.gemspec
+++ b/ephem.gemspec
@@ -29,8 +29,9 @@ Gem::Specification.new do |spec|
       )
     end
   end
-  spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.files += Dir["bin/*"]
+  spec.bindir = "bin"
+  spec.executables = ["ruby-ephem"]
   spec.require_paths = ["lib"]
 
   spec.add_dependency "numo-narray", "~> 0.9.2.1"

--- a/lib/ephem.rb
+++ b/lib/ephem.rb
@@ -19,6 +19,7 @@ require_relative "ephem/segments/base_segment"
 require_relative "ephem/segments/registry"
 require_relative "ephem/segments/segment"
 require_relative "ephem/excerpt"
+require_relative "ephem/cli"
 require_relative "ephem/version"
 
 module Ephem

--- a/lib/ephem.rb
+++ b/lib/ephem.rb
@@ -18,6 +18,7 @@ require_relative "ephem/spk"
 require_relative "ephem/segments/base_segment"
 require_relative "ephem/segments/registry"
 require_relative "ephem/segments/segment"
+require_relative "ephem/excerpt"
 require_relative "ephem/version"
 
 module Ephem

--- a/lib/ephem/cli.rb
+++ b/lib/ephem/cli.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "optparse"
+require "date"
+
+module Ephem
+  class CLI
+    def self.gregorian_to_julian(date_str)
+      date = Date.parse(date_str)
+
+      a = (14 - date.month) / 12
+      y = date.year + 4800 - a
+      m = date.month + 12 * a - 3
+
+      date.day +
+        ((153 * m + 2) / 5) +
+        365 * y +
+        (y / 4) -
+        (y / 100) +
+        (y / 400) -
+        32045
+    end
+
+    def self.start(args)
+      if args.empty?
+        puts "Usage: ruby-ephem excerpt [options] START_DATE END_DATE INPUT_FILE OUTPUT_FILE"
+        puts "For help: ruby-ephem help"
+        return
+      end
+
+      if args[0] == "help"
+        show_help
+        return
+      end
+
+      if args[0] == "excerpt"
+        handle_excerpt(args[1..-1])
+        return
+      end
+
+      puts "Unknown command: #{args[0]}"
+      puts "Available commands: excerpt, help"
+    end
+
+    def self.show_help
+      puts <<~HELP
+        Ruby Ephem - A tool for working with JPL Ephemerides
+
+        Commands:
+          excerpt - Create an excerpt of an SPK file
+          help    - Show this help message
+
+        Excerpt command:
+          ruby-ephem excerpt [options] START_DATE END_DATE INPUT_FILE OUTPUT_FILE
+
+        Options:
+          --targets TARGET_IDS  - Comma-separated list of target IDs to include
+                                  (default: all targets)
+
+        Example:
+          ruby-ephem excerpt --targets 3,10,399 2000-01-01 2030-01-01 de440s.bsp excerpt.bsp
+
+        This will create an excerpt of de440s.bsp containing only the specified
+        targets (Earth-Moon barycenter, Sun, Earth) for the period from
+        2000-01-01 to 2030-01-01.
+      HELP
+    end
+
+    # Handle the excerpt command
+    def self.handle_excerpt(args)
+      # Parse options
+      options = {target_ids: nil, debug: false}
+
+      option_parser = OptionParser.new do |opts|
+        opts.banner = "Usage: ruby-ephem excerpt [options] START_DATE END_DATE INPUT_FILE OUTPUT_FILE"
+
+        opts.on("--targets TARGET_IDS", "Comma-separated list of target IDs to include") do |targets|
+          options[:target_ids] = targets.split(",").map(&:strip).map(&:to_i)
+        end
+
+        opts.on("--debug", "Enable debug output") do
+          options[:debug] = true
+        end
+      end
+
+      begin
+        option_parser.parse!(args)
+      rescue OptionParser::InvalidOption => e
+        puts e.message
+        puts option_parser
+        return
+      end
+
+      if args.size < 4
+        puts "Not enough arguments."
+        puts option_parser
+        return
+      end
+
+      start_date_str = args[0]
+      end_date_str = args[1]
+      input_file = args[2]
+      output_file = args[3]
+
+      unless File.exist?(input_file)
+        puts "Error: Input file '#{input_file}' does not exist."
+        return
+      end
+
+      begin
+        start_jd = gregorian_to_julian(start_date_str)
+        end_jd = gregorian_to_julian(end_date_str)
+      rescue Date::Error => e
+        puts "Error parsing dates: #{e.message}"
+        puts "Dates should be in YYYY-MM-DD format."
+        return
+      end
+
+      begin
+        puts "Creating excerpt from #{input_file} to #{output_file}..."
+        puts "Date range: #{start_date_str} to #{end_date_str} (JD #{start_jd} to #{end_jd})"
+        if options[:target_ids]
+          puts "Including targets: #{options[:target_ids].join(", ")}"
+        else
+          puts "Including all targets"
+        end
+
+        spk = Ephem::SPK.open(input_file)
+
+        excerpt_spk = spk.excerpt(
+          output_path: output_file,
+          start_jd: start_jd,
+          end_jd: end_jd,
+          target_ids: options[:target_ids],
+          debug: options[:debug]
+        )
+
+        puts "Excerpt created successfully!"
+        puts "Original segments: #{spk.segments.size}"
+        puts "Excerpt segments: #{excerpt_spk.segments.size}"
+
+        original_size = File.size(input_file)
+        excerpt_size = File.size(output_file)
+        reduction_percentage =
+          ((original_size - excerpt_size) / original_size.to_f * 100).round(2)
+
+        puts "File size reduced by #{reduction_percentage}%"
+        puts "Original: #{original_size} bytes"
+        puts "Excerpt: #{excerpt_size} bytes"
+
+        spk.close
+        excerpt_spk.close
+      rescue => e
+        puts "Error creating excerpt: #{e.message}"
+        puts e.backtrace if options[:debug]
+      end
+    end
+  end
+end

--- a/lib/ephem/excerpt.rb
+++ b/lib/ephem/excerpt.rb
@@ -1,0 +1,382 @@
+# frozen_string_literal: true
+
+module Ephem
+  # The Excerpt class creates SPK file excerpts with reduced time spans and
+  # target bodies. This is useful for creating smaller files that focus only on
+  # the data needed for specific applications.
+  #
+  # @example Create an excerpt with specific time range and bodies
+  #   spk = Ephem::SPK.open("de421.bsp")
+  #   excerpt = Ephem::Excerpt.new(spk).extract(
+  #     output_path: "excerpt.bsp",
+  #     start_jd: 2458849.5,           # January 1, 2020
+  #     end_jd: 2459580.5,             # December 31, 2021
+  #     target_ids: [3, 10, 301, 399]  # Earth-Moon, Sun, Moon, Earth
+  #   )
+  class Excerpt
+    # Constants for time calculations
+    S_PER_DAY = Core::Constants::Time::SECONDS_PER_DAY
+    J2000_EPOCH = Core::Constants::Time::J2000_EPOCH
+    RECORD_SIZE = 1024
+
+    # @param spk [Ephem::SPK] The SPK object to create an excerpt from
+    def initialize(spk)
+      @spk = spk
+      @daf = spk.instance_variable_get(:@daf)
+      @binary_reader = @daf.instance_variable_get(:@binary_reader)
+    end
+
+    # Creates an excerpt of the SPK file
+    #
+    # @param output_path [String] Path where the excerpt will be written
+    # @param start_jd [Float] Start time as Julian Date
+    # @param end_jd [Float] End time as Julian Date
+    # @param target_ids [Array<Integer>, nil] Optional list of target IDs to
+    #   include
+    # @param debug [Boolean] Whether to print debug information
+    #
+    # @return [Ephem::SPK] A new SPK instance for the excerpt file
+    def extract(output_path:, start_jd:, end_jd:, target_ids: nil, debug: false)
+      start_seconds = seconds_since_j2000(start_jd)
+      end_seconds = seconds_since_j2000(end_jd)
+      output_file = File.open(output_path, "wb+")
+      copy_file_header(output_file)
+      initialize_summary_section(output_file)
+      writer = create_daf_writer(output_file, debug)
+      process_segments(writer, start_seconds, end_seconds, target_ids, debug)
+      output_file.close
+
+      SPK.open(output_path)
+    end
+
+    private
+
+    def seconds_since_j2000(jd)
+      (jd - J2000_EPOCH) * S_PER_DAY
+    end
+
+    def copy_file_header(output_file)
+      # Get the first record number of summaries from original DAF
+      fward = @daf.record_data.forward_record
+
+      # Copy file record and comments
+      (1...fward).each do |n|
+        data = @binary_reader.read_record(n)
+        output_file.write(data)
+      end
+    end
+
+    def initialize_summary_section(output_file)
+      summary_data = "\0".ljust(RECORD_SIZE, "\0")
+      name_data = " ".ljust(RECORD_SIZE, "\0")
+      output_file.write(summary_data)
+      output_file.write(name_data)
+    end
+
+    def create_daf_writer(output_file, debug)
+      writer = DAFWriter.new(output_file, debug)
+      fward = @daf.record_data.forward_record
+      writer.fward = writer.bward = fward
+      writer.free = (fward + 1) * (RECORD_SIZE / 8) + 1
+      writer.endianness = @daf.endianness
+      writer.setup_formats(
+        @daf.record_data.double_count,
+        @daf.record_data.integer_count
+      )
+      writer.write_file_record
+
+      writer
+    end
+
+    def process_segments(writer, start_seconds, end_seconds, target_ids, debug)
+      segments_processed = 0
+      segments_included = 0
+
+      # Get all summaries from the original DAF
+      @daf.summaries.each do |name, values|
+        segments_processed += 1
+
+        # Filter by target ID if specified
+        if target_ids && !target_ids.empty?
+          # The target ID is at index 2 in the summary values
+          target_id = values[2].to_i
+
+          unless target_ids.include?(target_id)
+            if debug
+              puts "Segment #{segments_processed} (#{name}):"
+              puts "Target ID #{target_id} not in requested list, skipping"
+            end
+
+            next
+          end
+        end
+
+        # Extract segment data
+        if extract_segment(
+          writer,
+          name,
+          values,
+          start_seconds,
+          end_seconds,
+          segments_processed,
+          debug
+        )
+          segments_included += 1
+        end
+      end
+
+      if debug
+        puts "Summary:"
+        puts "Processed #{segments_processed} segments,"
+        puts "included #{segments_included} in the excerpt"
+      end
+    end
+
+    def extract_segment(
+      writer,
+      name,
+      values,
+      start_seconds,
+      end_seconds,
+      segment_index,
+      debug
+    )
+      # Get start and end positions of the segment in the file
+      start_pos, end_pos = values[-2], values[-1]
+
+      if debug
+        puts "Processing segment #{segment_index} (#{name}):"
+        puts "start=#{start_pos}, end=#{end_pos}"
+      end
+
+      # Read the metadata from the end of the array
+      init, intlen, rsize, n = @daf.read_array(end_pos - 3, end_pos)
+      rsize = rsize.to_i
+
+      if debug
+        puts "  Metadata: init=#{init}, intlen=#{intlen}, rsize=#{rsize}, n=#{n}"
+      end
+
+      # Calculate which portion of the data to extract based on the date range
+      i = clip(0, n, ((start_seconds - init) / intlen)).to_i
+      j = clip(0, n, ((end_seconds - init) / intlen + 1)).to_i
+
+      puts "  Date range: i=#{i}, j=#{j} out of n=#{n}" if debug
+
+      # Skip if no overlap with requested date range
+      if i == j
+        if debug
+          puts "Segment #{segment_index} (#{name}):"
+          puts "No overlap with requested date range"
+        end
+
+        return false
+      end
+
+      # Update initial time and number of records
+      init += i * intlen
+      n = j - i
+
+      puts "  New metadata: init=#{init}, n=#{n}" if debug
+
+      # Extract the relevant portion of the data
+      extra = 4  # Enough space for the metadata: [init intlen rsize n]
+      excerpt_start = start_pos + rsize * i
+      excerpt_end = start_pos + rsize * j + extra - 1
+
+      puts "  Reading array from #{excerpt_start} to #{excerpt_end}" if debug
+
+      excerpt = @daf.read_array(excerpt_start, excerpt_end)
+
+      puts "  Read #{excerpt.length} values" if debug
+
+      # Update the metadata in the excerpt
+      excerpt[-4..-1] = [init, intlen, rsize, n]
+
+      new_values = if values.length >= 2
+        [init, init + n * intlen] + values[2...-2]
+      else
+        [init, init + n * intlen]
+      end
+
+      puts "  New values: #{new_values.inspect}" if debug
+
+      # Add the extracted array to the output file
+      # Modify the name to indicate it's an excerpt (X prefix)
+      writer.add_array(
+        "X#{name[1..-1]}".force_encoding("ASCII-8BIT"),
+        new_values,
+        excerpt
+      )
+
+      if debug
+        puts "Segment #{segment_index} (#{name}):"
+        puts "Included in excerpt (#{i} to #{j} of #{n})"
+      end
+
+      true
+    rescue => e
+      puts "Error processing segment #{segment_index} (#{name}): #{e.message}"
+      puts e.backtrace.join("\n") if debug
+      false
+    end
+
+    # Clips a value between lower and upper bounds
+    def clip(lower, upper, n)
+      [lower, [upper, n].min].max
+    end
+
+    # Helper class for writing DAF files
+    # This class handles the low-level details of DAF file format
+    class DAFWriter
+      attr_reader :file
+      attr_accessor :fward,
+        :bward,
+        :free,
+        :endianness,
+        :double_format,
+        :int_format,
+        :nd,
+        :ni,
+        :summary_format,
+        :summary_control_format,
+        :summary_length,
+        :summary_step,
+        :summaries_per_record
+
+      def initialize(file, debug = false)
+        @file = file
+        @debug = debug
+        @mutex = Mutex.new
+      end
+
+      def setup_formats(nd, ni)
+        @nd = nd
+        @ni = ni
+
+        # Double is always 8 bytes, int is always 4 bytes
+        double_size = 8
+        int_size = 4
+
+        # Set formats based on endianness
+        if @endianness == :little
+          @double_format = "E"  # Little-endian double
+          @int_format = "l"     # Little-endian signed long (32-bit)
+        else
+          @double_format = "G"  # Big-endian double
+          @int_format = "l>"    # Big-endian signed long (32-bit)
+        end
+
+        # Create formats for summary structures
+        @summary_control_format =
+          "#{@double_format}#{@double_format}#{@double_format}"
+        @summary_format = @double_format.to_s * @nd + @int_format.to_s * @ni
+
+        # Calculate segment summary sizes
+        @summary_length = double_size * @nd + int_size * @ni
+
+        # Pad to 8 bytes
+        @summary_step = @summary_length + (-@summary_length % 8)
+
+        @summaries_per_record = (RECORD_SIZE - 8 * 3) / @summary_step
+      end
+
+      def write_file_record
+        @file.seek(0)
+        data = @file.read(RECORD_SIZE)
+
+        # Update pointers directly in the data buffer
+        fward_pos = 76
+        bward_pos = 80
+        free_pos = 84
+
+        if @endianness == :little
+          data[fward_pos, 4] = [@fward].pack("l")
+          data[bward_pos, 4] = [@bward].pack("l")
+          data[free_pos, 4] = [@free].pack("l")
+        else
+          data[fward_pos, 4] = [@fward].pack("N")
+          data[bward_pos, 4] = [@bward].pack("N")
+          data[free_pos, 4] = [@free].pack("N")
+        end
+
+        # Write the updated record back to the file
+        @file.seek(0)
+        @file.write(data)
+      end
+
+      def read_record(n)
+        @mutex.synchronize do
+          @file.seek(n * RECORD_SIZE - RECORD_SIZE)
+          @file.read(RECORD_SIZE)
+        end
+      end
+
+      def write_record(n, data)
+        @mutex.synchronize do
+          @file.seek(n * RECORD_SIZE - RECORD_SIZE)
+          @file.write(data)
+        end
+      end
+
+      def add_array(name, values, array)
+        record_number = @bward
+        data = read_record(record_number).dup
+
+        control_data = data[0, 24].unpack(@summary_control_format)
+        next_record = control_data[0].to_i
+        previous_record = control_data[1].to_i
+        n_summaries = control_data[2].to_i
+
+        if n_summaries < @summaries_per_record
+          # Add to the existing record
+          summary_record = record_number
+          data[0, 24] = [next_record, previous_record, n_summaries + 1]
+            .pack(@summary_control_format)
+          write_record(summary_record, data)
+        else
+          # Create a new record
+          summary_record = ((@free - 1) * 8 + 1023) / 1024 + 1
+          name_record = summary_record + 1
+          free_record = summary_record + 2
+
+          data[0, 24] = [summary_record, previous_record, n_summaries]
+            .pack(@summary_control_format)
+          write_record(record_number, data)
+
+          n_summaries = 0
+          summaries = [0, record_number, 1]
+            .pack(@summary_control_format)
+            .ljust(RECORD_SIZE, "\0")
+          names = " ".ljust(RECORD_SIZE, "\0")
+          write_record(summary_record, summaries)
+          write_record(name_record, names)
+
+          @bward = summary_record
+          @free = (free_record - 1) * RECORD_SIZE / 8 + 1
+        end
+
+        # Convert array to binary data
+        array_data = array.pack("#{@double_format}*")
+
+        start_word = @free
+        @file.seek((start_word - 1) * 8)
+        @file.write(array_data)
+        end_word = @file.tell / 8
+
+        @free = end_word + 1
+        write_file_record
+
+        # Using values up to nd+ni-2, then adding start_word and end_word
+        new_values = values[0, @nd + @ni - 2] + [start_word, end_word]
+
+        base = RECORD_SIZE * (summary_record - 1)
+        offset = n_summaries * @summary_step
+        @file.seek(base + 24 + offset)  # 24 is summary_control_struct size
+        @file.write(new_values.pack(@summary_format))
+        @file.seek(base + RECORD_SIZE + offset)
+        @file.write(name[0, @summary_length].ljust(@summary_step, " "))
+      end
+    end
+  end
+end

--- a/lib/ephem/spk.rb
+++ b/lib/ephem/spk.rb
@@ -97,6 +97,18 @@ module Ephem
       @segments.each(&block)
     end
 
+    def excerpt(output_path:, start_jd:, end_jd:, target_ids: nil, debug: false)
+      Excerpt
+        .new(self)
+        .extract(
+          output_path: output_path,
+          start_jd: start_jd,
+          end_jd: end_jd,
+          target_ids: target_ids,
+          debug: debug
+        )
+    end
+
     private
 
     def load_segments

--- a/spec/ephem/cli_spec.rb
+++ b/spec/ephem/cli_spec.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "fileutils"
+require "stringio"
+
+RSpec.describe Ephem::CLI do
+  include TestSpkHelper
+
+  describe ".gregorian_to_julian" do
+    it "converts a simple date correctly" do
+      julian_date = Ephem::CLI.gregorian_to_julian("2000-01-01")
+      expect(julian_date).to be_within(0.1).of(2451545.0)
+    end
+
+    it "converts multiple date formats" do
+      formats = {
+        "2000-01-01" => 2451545.0,
+        "2020-12-31" => 2459215.0,
+        "1900-01-01" => 2415021.0
+      }
+
+      formats.each do |date_str, expected_jd|
+        julian_date = Ephem::CLI.gregorian_to_julian(date_str)
+        expect(julian_date).to be_within(0.1).of(expected_jd)
+      end
+    end
+
+    it "raises an error for invalid dates" do
+      invalid_dates = %w[not-a-date 2000/13/01 2000-02-30]
+
+      invalid_dates.each do |date_str|
+        expect { Ephem::CLI.gregorian_to_julian(date_str) }
+          .to raise_error(Date::Error)
+      end
+    end
+  end
+
+  describe ".show_help" do
+    it "displays help information" do
+      output = capture_stdout { Ephem::CLI.show_help }
+
+      expect(output).to include("Ruby Ephem")
+      expect(output).to include("excerpt")
+      expect(output).to include("--targets")
+      expect(output).to include("Example:")
+    end
+  end
+
+  describe ".start" do
+    it "shows usage when no arguments given" do
+      output = capture_stdout { Ephem::CLI.start([]) }
+
+      expect(output).to include("Usage: ruby-ephem excerpt")
+    end
+
+    it "shows help when help command given" do
+      output = capture_stdout { Ephem::CLI.start(["help"]) }
+
+      expect(output).to include("Ruby Ephem")
+      expect(output).to include("Commands:")
+    end
+
+    it "runs excerpt command when given" do
+      expect(Ephem::CLI).to receive(:handle_excerpt).with(%w[arg1 arg2])
+      Ephem::CLI.start(%w[excerpt arg1 arg2])
+    end
+
+    it "shows error for unknown command" do
+      output = capture_stdout { Ephem::CLI.start(["unknown_command"]) }
+
+      expect(output).to include("Unknown command")
+      expect(output).to include("Available commands")
+    end
+  end
+
+  describe ".handle_excerpt" do
+    context "with insufficient arguments" do
+      it "shows an error message" do
+        output = capture_stdout { Ephem::CLI.handle_excerpt([]) }
+
+        expect(output).to include("Not enough arguments")
+      end
+    end
+
+    context "with nonexistent input file" do
+      it "shows an error message" do
+        args = %w[2000-01-01 2030-01-01 nonexistent.bsp output.bsp]
+
+        output = capture_stdout { Ephem::CLI.handle_excerpt(args) }
+
+        expect(output).to include("does not exist")
+      end
+    end
+
+    context "with invalid date format" do
+      it "shows an error message" do
+        args = %w[not-a-date 2030-01-01 input.bsp output.bsp]
+        FileUtils.touch("input.bsp")
+
+        begin
+          output = capture_stdout { Ephem::CLI.handle_excerpt(args) }
+          expect(output).to include("Error parsing dates")
+        ensure
+          FileUtils.rm("input.bsp") if File.exist?("input.bsp")
+        end
+      end
+    end
+
+    context "with valid arguments" do
+      it "creates an excerpt with specified targets" do
+        temp_dir = Dir.mktmpdir("ephem_test_")
+        input_file = File.join(temp_dir, "input.bsp")
+        output_file = File.join(temp_dir, "output.bsp")
+
+        spk_path = test_spk
+
+        begin
+          FileUtils.cp(spk_path, input_file)
+
+          args = [
+            "--targets",
+            "3,10,399",
+            "2000-01-01",
+            "2030-01-01",
+            input_file,
+            output_file
+          ]
+          output = capture_stdout { Ephem::CLI.handle_excerpt(args) }
+
+          expect(output).to include("Creating excerpt")
+          expect(output).to include("Including targets: 3, 10, 399")
+          expect(output).to include("Excerpt created successfully")
+          expect(File.exist?(output_file)).to be true
+        ensure
+          FileUtils.remove_entry(temp_dir) if Dir.exist?(temp_dir)
+        end
+      end
+
+      it "creates an excerpt with all targets when none specified" do
+        temp_dir = Dir.mktmpdir("ephem_test_")
+        input_file = File.join(temp_dir, "input.bsp")
+        output_file = File.join(temp_dir, "output.bsp")
+
+        spk_path = test_spk
+
+        begin
+          FileUtils.cp(spk_path, input_file)
+
+          args = ["2000-01-01", "2030-01-01", input_file, output_file]
+          output = capture_stdout { Ephem::CLI.handle_excerpt(args) }
+
+          expect(output).to include("Creating excerpt")
+          expect(output).to include("Including all targets")
+          expect(output).to include("Excerpt created successfully")
+          expect(File.exist?(output_file)).to be true
+        ensure
+          # Always clean up
+          FileUtils.remove_entry(temp_dir) if Dir.exist?(temp_dir)
+        end
+      end
+
+      it "shows debug output when requested" do
+        temp_dir = Dir.mktmpdir("ephem_test_")
+        input_file = File.join(temp_dir, "input.bsp")
+        output_file = File.join(temp_dir, "output.bsp")
+
+        spk_path = test_spk
+
+        begin
+          FileUtils.cp(spk_path, input_file)
+
+          args = [
+            "--debug",
+            "2000-01-01",
+            "2030-01-01",
+            input_file,
+            output_file
+          ]
+          output = capture_stdout { Ephem::CLI.handle_excerpt(args) }
+
+          expect(output).to include("Creating excerpt")
+          expect(File.exist?(output_file)).to be true
+        ensure
+          FileUtils.remove_entry(temp_dir) if Dir.exist?(temp_dir)
+        end
+      end
+    end
+  end
+
+  def capture_stdout
+    original_stdout = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original_stdout
+  end
+end

--- a/spec/ephem/excerpt_spec.rb
+++ b/spec/ephem/excerpt_spec.rb
@@ -1,0 +1,279 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "tmpdir"
+
+RSpec.describe Ephem::Excerpt do
+  include TestSpkHelper
+
+  describe "#extract" do
+    it "includes only the specified target segments" do
+      temp_dir = Dir.mktmpdir("ephem_test_")
+      original_spk_path = test_spk
+      excerpt_path = File.join(temp_dir, "excerpt.bsp")
+      start_jd = 2458849.5
+      end_jd = 2459580.5
+      target_ids = [3, 10, 301, 399]
+      original_spk = Ephem::SPK.open(original_spk_path)
+      excerpt_spk = original_spk.excerpt(
+        output_path: excerpt_path,
+        start_jd: start_jd,
+        end_jd: end_jd,
+        target_ids: target_ids
+      )
+
+      expect(excerpt_spk.segments.size).to eq target_ids.size
+      segment_targets = excerpt_spk.segments.map(&:target)
+      target_ids.each do |target_id|
+        expect(segment_targets).to include(target_id)
+      end
+
+      original_spk.close
+      excerpt_spk.close
+    end
+
+    it "produces a smaller file than the original" do
+      temp_dir = Dir.mktmpdir("ephem_test_")
+      original_spk_path = test_spk
+      excerpt_path = File.join(temp_dir, "excerpt.bsp")
+      start_jd = 2458849.5
+      end_jd = 2459580.5
+      target_ids = [3, 10, 301, 399]
+      original_spk = Ephem::SPK.open(original_spk_path)
+      excerpt_spk = original_spk.excerpt(
+        output_path: excerpt_path,
+        start_jd: start_jd,
+        end_jd: end_jd,
+        target_ids: target_ids
+      )
+
+      original_size = File.size(original_spk_path)
+      excerpt_size = File.size(excerpt_path)
+      expect(excerpt_size).to be < original_size
+
+      original_spk.close
+      excerpt_spk.close
+    end
+
+    it "produces identical computation results using SPK#excerpt" do
+      temp_dir = Dir.mktmpdir("ephem_test_")
+      original_spk_path = test_spk
+      excerpt_path = File.join(temp_dir, "excerpt.bsp")
+      start_jd = 2458849.5
+      end_jd = 2459580.5
+      target_ids = [3, 10, 301, 399]
+      test_time = 2459000.0
+      center = 0
+      target = 3
+      original_spk = Ephem::SPK.open(original_spk_path)
+      excerpt_spk = original_spk.excerpt(
+        output_path: excerpt_path,
+        start_jd: start_jd,
+        end_jd: end_jd,
+        target_ids: target_ids
+      )
+      original_segment = original_spk[center, target]
+      excerpt_segment = excerpt_spk[center, target]
+      original_state = original_segment.compute_and_differentiate(test_time)
+      excerpt_state = excerpt_segment.compute_and_differentiate(test_time)
+
+      expect(excerpt_state.position.to_a).to eq original_state.position.to_a
+      expect(excerpt_state.velocity.to_a).to eq original_state.velocity.to_a
+
+      original_spk.close
+      excerpt_spk.close
+    end
+
+    it "produces identical computation results using Excerpt directly" do
+      temp_dir = Dir.mktmpdir("ephem_test_")
+      original_spk_path = test_spk
+      excerpt_path = File.join(temp_dir, "excerpt.bsp")
+      start_jd = 2458849.5
+      end_jd = 2459580.5
+      target_ids = [3, 10, 301, 399]
+      test_time = 2459000.0
+      center = 0
+      target = 3
+      original_spk = Ephem::SPK.open(original_spk_path)
+      excerpt_spk = Ephem::Excerpt.new(original_spk).extract(
+        output_path: excerpt_path,
+        start_jd: start_jd,
+        end_jd: end_jd,
+        target_ids: target_ids
+      )
+      original_segment = original_spk[center, target]
+      excerpt_segment = excerpt_spk[center, target]
+      original_state = original_segment.compute_and_differentiate(test_time)
+      excerpt_state = excerpt_segment.compute_and_differentiate(test_time)
+
+      expect(excerpt_state.position.to_a).to eq original_state.position.to_a
+      expect(excerpt_state.velocity.to_a).to eq original_state.velocity.to_a
+
+      original_spk.close
+      excerpt_spk.close
+    end
+
+    it "handles a short time span correctly" do
+      temp_dir = Dir.mktmpdir("ephem_test_")
+      original_spk_path = test_spk
+      excerpt_path = File.join(temp_dir, "excerpt.bsp")
+      start_jd = 2459000.0
+      end_jd = 2459001.0
+      target_ids = [3, 10, 301, 399]
+      test_time = 2459000.5
+      center = 0
+      target = 3
+      original_spk = Ephem::SPK.open(original_spk_path)
+      excerpt_spk = original_spk.excerpt(
+        output_path: excerpt_path,
+        start_jd: start_jd,
+        end_jd: end_jd,
+        target_ids: target_ids
+      )
+      original_segment = original_spk[center, target]
+      excerpt_segment = excerpt_spk[center, target]
+      original_state = original_segment.compute_and_differentiate(test_time)
+      excerpt_state = excerpt_segment.compute_and_differentiate(test_time)
+
+      expect(excerpt_state.position.to_a).to eq original_state.position.to_a
+      expect(excerpt_state.velocity.to_a).to eq original_state.velocity.to_a
+
+      original_spk.close
+      excerpt_spk.close
+    end
+
+    it "works with a single target ID" do
+      temp_dir = Dir.mktmpdir("ephem_test_")
+      original_spk_path = test_spk
+      excerpt_path = File.join(temp_dir, "excerpt.bsp")
+      start_jd = 2458849.5
+      end_jd = 2459580.5
+      target_ids = [3]
+      test_time = 2459000.0
+      center = 0
+      target = 3
+      original_spk = Ephem::SPK.open(original_spk_path)
+      excerpt_spk = original_spk.excerpt(
+        output_path: excerpt_path,
+        start_jd: start_jd,
+        end_jd: end_jd,
+        target_ids: target_ids
+      )
+
+      expect(excerpt_spk.segments.size).to eq 1
+      expect(excerpt_spk.segments.first.target).to eq target_ids.first
+      original_segment = original_spk[center, target]
+      excerpt_segment = excerpt_spk[center, target]
+      original_state = original_segment.compute_and_differentiate(test_time)
+      excerpt_state = excerpt_segment.compute_and_differentiate(test_time)
+      expect(excerpt_state.position.to_a).to eq original_state.position.to_a
+      expect(excerpt_state.velocity.to_a).to eq original_state.velocity.to_a
+
+      original_spk.close
+      excerpt_spk.close
+    end
+
+    it "raises an error for time outside excerpt range but works in original" do
+      temp_dir = Dir.mktmpdir("ephem_test_")
+      original_spk_path = test_spk
+      excerpt_path = File.join(temp_dir, "excerpt.bsp")
+      start_jd = 2458849.5
+      end_jd = 2459580.5
+      target_ids = [3, 10, 301, 399]
+      outside_time = 2460000.0
+      center = 0
+      target = 3
+      original_spk = Ephem::SPK.open(original_spk_path)
+      excerpt_spk = original_spk.excerpt(
+        output_path: excerpt_path,
+        start_jd: start_jd,
+        end_jd: end_jd,
+        target_ids: target_ids
+      )
+      original_segment = original_spk[center, target]
+      excerpt_segment = excerpt_spk[center, target]
+
+      expect {
+        excerpt_segment.compute_and_differentiate(outside_time)
+      }.to raise_error(Ephem::OutOfRangeError)
+      expect {
+        original_segment.compute_and_differentiate(outside_time)
+      }.not_to raise_error
+
+      original_spk.close
+      excerpt_spk.close
+    end
+
+    it "produces correct results for multiple test times" do
+      temp_dir = Dir.mktmpdir("ephem_test_")
+      original_spk_path = test_spk
+      excerpt_path = File.join(temp_dir, "excerpt.bsp")
+      start_jd = 2458849.5
+      end_jd = 2459580.5
+      target_ids = [3, 10, 301, 399]
+      test_times = [
+        2458849.5,
+        2459000.0,
+        2459215.0,
+        2459580.5
+      ]
+      center = 0
+      target = 3
+      original_spk = Ephem::SPK.open(original_spk_path)
+      excerpt_spk = original_spk.excerpt(
+        output_path: excerpt_path,
+        start_jd: start_jd,
+        end_jd: end_jd,
+        target_ids: target_ids
+      )
+      original_segment = original_spk[center, target]
+      excerpt_segment = excerpt_spk[center, target]
+
+      test_times.each do |time|
+        original_state = original_segment.compute_and_differentiate(time)
+        excerpt_state = excerpt_segment.compute_and_differentiate(time)
+        expect(excerpt_state.position.to_a).to eq original_state.position.to_a
+        expect(excerpt_state.velocity.to_a).to eq original_state.velocity.to_a
+      end
+
+      original_spk.close
+      excerpt_spk.close
+    end
+
+    it "produces correct results for multiple center-target pairs" do
+      temp_dir = Dir.mktmpdir("ephem_test_")
+      original_spk_path = test_spk
+      excerpt_path = File.join(temp_dir, "excerpt.bsp")
+
+      start_jd = 2458849.5
+      end_jd = 2459580.5
+      target_ids = [3, 10, 301, 399]
+      test_time = 2459000.0
+      test_pairs = [
+        [0, 3],
+        [0, 10],
+        [3, 301],
+        [3, 399]
+      ]
+      original_spk = Ephem::SPK.open(original_spk_path)
+      excerpt_spk = original_spk.excerpt(
+        output_path: excerpt_path,
+        start_jd: start_jd,
+        end_jd: end_jd,
+        target_ids: target_ids
+      )
+
+      test_pairs.each do |center, target|
+        original_segment = original_spk[center, target]
+        excerpt_segment = excerpt_spk[center, target]
+        original_state = original_segment.compute_and_differentiate(test_time)
+        excerpt_state = excerpt_segment.compute_and_differentiate(test_time)
+        expect(excerpt_state.position.to_a).to eq original_state.position.to_a
+        expect(excerpt_state.velocity.to_a).to eq original_state.velocity.to_a
+      end
+
+      original_spk.close
+      excerpt_spk.close
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,8 @@
 
 require "ephem"
 
+require "support/test_spk_helper"
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"

--- a/spec/support/test_spk_helper.rb
+++ b/spec/support/test_spk_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module TestSpkHelper
+  def test_spk
+    File.path("#{__dir__}/data/de421.bsp")
+  end
+end


### PR DESCRIPTION
SPK can be large files, especially if they cover a large range of time.

Take `de441`, it covers from -13200 to 17191 and its size is 3.1 GB.
What if you need data for year 3000, and only for the Sun? You would need to deal with this massive ephemeris which takes a long time to be parsed and used.

This introduces the ability to create an excerpt from an original SPK by reducing the targets and/or the time range.

```
$ ruby-ephem excerpt --targets 10 2100-01-01 2101-01-01 de430.bsp excerpt.bsp
```

`de430.bsp` is 120 MB while `excerpt.bsp` is 12 KB.

This should be particularly convenient when you are limited in the targets you need and the years you want to support.