### PR TITLE
Add `irb` to dev dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,13 @@ GEM
   specs:
     ast (2.4.2)
     csv (3.3.3)
+    date (3.4.1)
     diff-lcs (1.5.1)
+    io-console (0.8.0)
+    irb (1.15.1)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.10.2)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
@@ -18,10 +24,20 @@ GEM
     parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
+    psych (5.2.3)
+      date
+      stringio
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
+    rdoc (6.12.0)
+      psych (>= 4.0.0)
     regexp_parser (2.10.0)
+    reline (0.6.0)
+      io-console (~> 0.5)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -65,6 +81,7 @@ GEM
     standard-performance (1.7.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.24.0)
+    stringio (3.1.5)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -76,6 +93,7 @@ PLATFORMS
 DEPENDENCIES
   csv (~> 3.3)
   ephem!
+  irb (~> 1.15)
   parallel (~> 1.26)
   rake (~> 13.0)
   rspec (~> 3.13)

--- a/ephem.gemspec
+++ b/ephem.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "numo-narray", "~> 0.9.2.1"
 
   spec.add_development_dependency "csv", "~> 3.3"
+  spec.add_development_dependency "irb", "~> 1.15"
   spec.add_development_dependency "parallel", "~> 1.26"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.13"


### PR DESCRIPTION
Fixes warning from `bin/console`:

```
bin/console:10: warning: irb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add irb to your Gemfile or gemspec to silence this warning.
```