### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,41 @@
-## [Unreleased]
+# Changelog
+
+## [0.2.0] - 2025-03-28
+
+### Features
+
+* Simplify download ([#12])
+* SPK excerpt generator ([#13])
+* Improve documentation on excerpts ([#16])
+
+### Improvements
+
+* Add Dependabot ([#6])
+* Replace testing kernel ([#17])
+* Add `irb` to dev dependencies ([#14])
+* Add support for Rubies `3.2.7` and `3.4.2` ([#15])
+* Bump csv from 3.3.0 to 3.3.2 by @dependabot ([#7])
+* Bump standard from 1.43.0 to 1.44.0 by @dependabot ([#8])
+* Bump standard from 1.44.0 to 1.45.0 by @dependabot ([#9])
+* Bump csv from 3.3.2 to 3.3.3 by @dependabot ([#11])
+* Bump standard from 1.45.0 to 1.47.0 by @dependabot ([#10])
+* Bump json from 2.10.1 to 2.10.2 by @dependabot ([#18])
+
+[#6]: https://github.com/rhannequin/ruby-ephem/pull/6
+[#7]: https://github.com/rhannequin/ruby-ephem/pull/7
+[#8]: https://github.com/rhannequin/ruby-ephem/pull/8
+[#9]: https://github.com/rhannequin/ruby-ephem/pull/9
+[#10]: https://github.com/rhannequin/ruby-ephem/pull/10
+[#11]: https://github.com/rhannequin/ruby-ephem/pull/11
+[#12]: https://github.com/rhannequin/ruby-ephem/pull/12
+[#13]: https://github.com/rhannequin/ruby-ephem/pull/13
+[#14]: https://github.com/rhannequin/ruby-ephem/pull/14
+[#15]: https://github.com/rhannequin/ruby-ephem/pull/15
+[#16]: https://github.com/rhannequin/ruby-ephem/pull/16
+[#17]: https://github.com/rhannequin/ruby-ephem/pull/17
+[#18]: https://github.com/rhannequin/ruby-ephem/pull/18
+
+**Full Changelog**: https://github.com/rhannequin/ruby-ephem/compare/v0.1.0...v0.2.0
 
 ## [0.1.0] - 2025-01-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Simplify download ([#12])
 * SPK excerpt generator ([#13])
 * Improve documentation on excerpts ([#16])
+* IMCCE INPOP support ([#20])
 
 ### Improvements
 
@@ -21,6 +22,12 @@
 * Bump standard from 1.45.0 to 1.47.0 by @dependabot ([#10])
 * Bump json from 2.10.1 to 2.10.2 by @dependabot ([#18])
 
+### New Contributors
+
+* @dependabot made their first contribution in [#7]
+
+**Full Changelog**: https://github.com/rhannequin/ruby-ephem/compare/v0.1.0...v0.2.0
+
 [#6]: https://github.com/rhannequin/ruby-ephem/pull/6
 [#7]: https://github.com/rhannequin/ruby-ephem/pull/7
 [#8]: https://github.com/rhannequin/ruby-ephem/pull/8
@@ -34,8 +41,7 @@
 [#16]: https://github.com/rhannequin/ruby-ephem/pull/16
 [#17]: https://github.com/rhannequin/ruby-ephem/pull/17
 [#18]: https://github.com/rhannequin/ruby-ephem/pull/18
-
-**Full Changelog**: https://github.com/rhannequin/ruby-ephem/compare/v0.1.0...v0.2.0
+[#20]: https://github.com/rhannequin/ruby-ephem/pull/20
 
 ## [0.1.0] - 2025-01-01
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ephem (0.1.0)
+    ephem (0.2.0)
       minitar (~> 0.12)
       numo-narray (~> 0.9.2.1)
       zlib (~> 3.2)

--- a/lib/ephem/version.rb
+++ b/lib/ephem/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ephem
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
## [0.2.0] - 2025-03-28

### Features

* Simplify download ([#12])
* SPK excerpt generator ([#13])
* Improve documentation on excerpts ([#16])
* IMCCE INPOP support ([#20])

### Improvements

* Add Dependabot ([#6])
* Replace testing kernel ([#17])
* Add `irb` to dev dependencies ([#14])
* Add support for Rubies `3.2.7` and `3.4.2` ([#15])
* Bump csv from 3.3.0 to 3.3.2 by @dependabot ([#7])
* Bump standard from 1.43.0 to 1.44.0 by @dependabot ([#8])
* Bump standard from 1.44.0 to 1.45.0 by @dependabot ([#9])
* Bump csv from 3.3.2 to 3.3.3 by @dependabot ([#11])
* Bump standard from 1.45.0 to 1.47.0 by @dependabot ([#10])
* Bump json from 2.10.1 to 2.10.2 by @dependabot ([#18])

[#6]: https://github.com/rhannequin/ruby-ephem/pull/6
[#7]: https://github.com/rhannequin/ruby-ephem/pull/7
[#8]: https://github.com/rhannequin/ruby-ephem/pull/8
[#9]: https://github.com/rhannequin/ruby-ephem/pull/9
[#10]: https://github.com/rhannequin/ruby-ephem/pull/10
[#11]: https://github.com/rhannequin/ruby-ephem/pull/11
[#12]: https://github.com/rhannequin/ruby-ephem/pull/12
[#13]: https://github.com/rhannequin/ruby-ephem/pull/13
[#14]: https://github.com/rhannequin/ruby-ephem/pull/14
[#15]: https://github.com/rhannequin/ruby-ephem/pull/15
[#16]: https://github.com/rhannequin/ruby-ephem/pull/16
[#17]: https://github.com/rhannequin/ruby-ephem/pull/17
[#18]: https://github.com/rhannequin/ruby-ephem/pull/18
[#20]: https://github.com/rhannequin/ruby-ephem/pull/20

### New Contributors

* @dependabot made their first contribution in [#7]

**Full Changelog**: https://github.com/rhannequin/ruby-ephem/compare/v0.1.0...v0.2.0