### PR TITLE
IMCCE INPOP support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,9 @@ PATH
   remote: .
   specs:
     ephem (0.1.0)
+      minitar (~> 1.0)
       numo-narray (~> 0.9.2.1)
+      zlib (~> 3.2)
 
 GEM
   remote: https://rubygems.org/
@@ -19,6 +21,7 @@ GEM
     json (2.10.2)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
+    minitar (1.0.2)
     numo-narray (0.9.2.1)
     parallel (1.26.3)
     parser (3.3.7.1)
@@ -85,6 +88,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    zlib (3.2.1)
 
 PLATFORMS
   arm64-darwin-23

--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 # Ephem
 
-Ephem is a Ruby gem that provides a simple interface to the JPL Development
-Ephemeris (DE) series as SPICE binary kernel files. The DE series is a
-collection of numerical integrations of the equations of motion of the solar
-system, used to calculate the positions of the planets, the Moon, and other
-celestial bodies with high precision.
+Ephem is a Ruby gem that provides a simple interface to the SPICE binary kernel
+files such as:
+* _JPL [Development Ephemeris]_ (DE)
+* _IMCCE [Intégrateur numérique planétaire de l'Observatoire de Paris]_ (INPOP)
 
-Ephem currently only support planetary ephemerides like DE405, DE421, DE430,
-etc.
+[Development Ephemeris]: https://ssd.jpl.nasa.gov/planets/eph_export.html
+[Intégrateur numérique planétaire de l'Observatoire de Paris]: https://www.imcce.fr/inpop
 
-The library in high development mode and does not have a stable version yet.
+These files are a collection of numerical integrations of the equations of
+motion of the Solar System, used to calculate the positions of the planets,
+the Moon, and other celestial bodies with high precision.
+
+Ephem currently only support planetary ephemerides like DE421, DE430,
+INPOP19A, etc.
+
+The library is in high development mode and does not have a stable version yet.
 The API is subject to major changes at the moment, please keep that in mind if
 you consider adding this gem as a dependency.
 
@@ -30,11 +36,13 @@ gem install ephem
 
 ## How to select the right kernel file
 
-JPL produces many different kernels over the years, with different accuracy and
-ranges of supported years. Here are some that we would recommend to begin with:
+JPL and IMCCE produces many different kernels over the years, with different
+accuracy and ranges of supported years. Here are some that we would recommend to
+begin with:
 
 * `de421.bsp`: from 1900 to 2050, 17 MB
 * `de440s.bsp`: from 1849 to 2150, 32 MB
+* `inpop19a.bsp`: from 1900 to 2100, 22 MB
 
 ## Usage
 

--- a/ephem.gemspec
+++ b/ephem.gemspec
@@ -34,7 +34,9 @@ Gem::Specification.new do |spec|
   spec.executables = ["ruby-ephem"]
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "minitar", "~> 1.0"
   spec.add_dependency "numo-narray", "~> 0.9.2.1"
+  spec.add_dependency "zlib", "~> 3.2"
 
   spec.add_development_dependency "csv", "~> 3.3"
   spec.add_development_dependency "irb", "~> 1.15"

--- a/lib/ephem/download.rb
+++ b/lib/ephem/download.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
+require "minitar"
 require "net/http"
+require "tempfile"
+require "zlib"
 
 module Ephem
   class Download
-    BASE_URL = "https://ssd.jpl.nasa.gov/ftp/eph/planets/bsp/"
+    JPL_BASE_URL = "https://ssd.jpl.nasa.gov/ftp/eph/planets/bsp/"
+    IMCCE_BASE_URL = "https://ftp.imcce.fr/pub/ephem/planets/"
 
-    SUPPORTED_KERNELS = %w[
+    JPL_KERNELS = %w[
       de102.bsp
       de200.bsp
       de202.bsp
@@ -53,6 +57,39 @@ module Ephem
       de441.bsp
     ].freeze
 
+    IMCCE_KERNELS = {
+      "inpop10b.bsp" => "inpop10b_TDB_m100_p100_spice.bsp",
+      "inpop10b_large.bsp" => "inpop10b_TDB_m1000_p1000_spice.bsp",
+      "inpop10e.bsp" => "inpop10e_TDB_m100_p100_spice.bsp",
+      "inpop10e_large.bsp" => "inpop10e_TDB_m1000_p1000_spice.bsp",
+      "inpop13c.bsp" => "inpop13c_TDB_m100_p100_spice.bsp",
+      "inpop13c_large.bsp" => "inpop13c_TDB_m1000_p1000_spice.bsp",
+      "inpop17a.bsp" => "inpop17a_TDB_m100_p100_spice.bsp",
+      "inpop17a_large.bsp" => "inpop17a_TDB_m1000_p1000_spice.bsp",
+      "inpop19a.bsp" => "inpop19a_TDB_m100_p100_spice.bsp",
+      "inpop19a_large.bsp" => "inpop19a_TDB_m1000_p1000_spice.bsp",
+      "inpop21a.bsp" => "inpop21a_TDB_m100_p100_spice.bsp",
+      "inpop21a_large.bsp" => "inpop21a_TDB_m1000_p1000_spice.bsp"
+    }.freeze
+
+    IMCCE_KERNELS_MATCHING = {
+      "inpop10b.bsp" => "inpop10b/inpop10b_TDB_m100_p100_spice.tar.gz",
+      "inpop10b_large.bsp" => "inpop10b/inpop10b_TDB_m1000_p1000_spice.tar.gz",
+      "inpop10e.bsp" => "inpop10e/inpop10e_TDB_m100_p100_spice_release2.tar.gz",
+      "inpop10e_large.bsp" =>
+        "inpop10e/inpop10e_TDB_m1000_p1000_spice_release2.tar.gz",
+      "inpop13c.bsp" => "inpop13c/inpop13c_TDB_m100_p100_spice.tar.gz",
+      "inpop13c_large.bsp" => "inpop13c/inpop13c_TDB_m1000_p1000_spice.tar.gz",
+      "inpop17a.bsp" => "inpop17a/inpop17a_TDB_m100_p100_spice.tar.gz",
+      "inpop17a_large.bsp" => "inpop17a/inpop17a_TDB_m1000_p1000_spice.tar.gz",
+      "inpop19a.bsp" => "inpop19a/inpop19a_TDB_m100_p100_spice.tar.gz",
+      "inpop19a_large.bsp" => "inpop19a/inpop19a_TDB_m1000_p1000_spice.tar.gz",
+      "inpop21a.bsp" => "inpop21a/inpop21a_TDB_m100_p100_spice.tar.gz",
+      "inpop21a_large.bsp" => "inpop21a/inpop21a_TDB_m1000_p1000_spice.tar.gz"
+    }.freeze
+
+    SUPPORTED_KERNELS = (JPL_KERNELS + IMCCE_KERNELS.keys).freeze
+
     def self.call(name:, target:)
       new(name, target).call
     end
@@ -64,8 +101,7 @@ module Ephem
     end
 
     def call
-      uri = URI("#{BASE_URL}#{@name}")
-      content = Net::HTTP.get(uri)
+      content = jpl_kernel? ? download_from_jpl : download_from_imcce
       File.write(@local_path, content)
 
       true
@@ -78,6 +114,34 @@ module Ephem
         raise UnsupportedError,
           "Kernel #{@name} is not supported by the library at the moment."
       end
+    end
+
+    def jpl_kernel?
+      JPL_KERNELS.include?(@name)
+    end
+
+    def download_from_jpl
+      uri = URI("#{JPL_BASE_URL}#{@name}")
+      Net::HTTP.get(uri)
+    end
+
+    def download_from_imcce
+      temp_file = Tempfile.new(%w[archive .tar.gz])
+      uri = URI("#{IMCCE_BASE_URL}#{IMCCE_KERNELS_MATCHING[@name]}")
+      content = Net::HTTP.get(uri)
+      temp_file.write(content)
+      temp_file.rewind
+
+      Zlib::GzipReader.open(temp_file.path) do |gz|
+        Minitar::Reader.open(gz) do |tar|
+          tar.each_entry do |entry|
+            return entry.read if entry.full_name == IMCCE_KERNELS[@name]
+          end
+        end
+      end
+    ensure
+      temp_file.close
+      temp_file.unlink
     end
   end
 end

--- a/spec/ephem/download_spec.rb
+++ b/spec/ephem/download_spec.rb
@@ -2,6 +2,35 @@
 
 RSpec.describe Ephem::Download do
   describe ".call" do
+    context "when downloading a JPL kernel" do
+      it "downloads and writes the JPL kernel file" do
+        name = "de440.bsp"
+        target_path = "tmp/kernel.bsp"
+        mock_content = "large-binary-data"
+        allow(Net::HTTP).to receive(:get).and_return(mock_content)
+        allow(File).to receive(:write)
+
+        described_class.call(name: name, target: target_path)
+
+        expect(File).to have_received(:write).with(target_path, mock_content)
+      end
+    end
+
+    context "when downloading an IMCCE kernel" do
+      it "downloads, extracts, and writes the IMCCE kernel file" do
+        name = "inpop19a.bsp"
+        target_path = "tmp/kernel.bsp"
+        mock_content = "large-binary-data"
+        tar_gz_file = create_temp_tar_gz_with(name => mock_content)
+        allow(Net::HTTP).to receive(:get).and_return(tar_gz_file.read)
+        allow(File).to receive(:write)
+
+        described_class.call(name: name, target: target_path)
+
+        expect(File).to have_received(:write).with(target_path, mock_content)
+      end
+    end
+
     context "when the kernel is not supported" do
       it "raises an UnsupportedError" do
         expect { described_class.call(name: "unsupported", target: "path") }.to(
@@ -11,6 +40,27 @@ RSpec.describe Ephem::Download do
           )
         )
       end
+    end
+  end
+
+  def create_temp_tar_gz_with(files)
+    Tempfile.new.tap do |tempfile|
+      Zlib::GzipWriter.open(tempfile) do |gz|
+        Minitar::Writer.open(gz) do |tar|
+          files.each do |filename, content|
+            io = StringIO.new(content)
+            tar.add_file_simple(
+              described_class::IMCCE_KERNELS[filename],
+              size: content.bytesize,
+              mode: 0o644,
+              mtime: Time.now.to_i
+            ) do |out|
+              IO.copy_stream(io, out)
+            end
+          end
+        end
+      end
+      tempfile.rewind
     end
   end
 end


### PR DESCRIPTION
I can't hide this change makes me super happy.

_INPOP_ is the ephemerides series from the Paris Observatory, more precisely from the IMCCE laboratory. The Paris Observatory has been a central place for astronomy for the last few centuries and the data produces today by the IMCCE is among the most accurate and precise we can produce today.

I frequently use data from the IMCCE in the development and tests of Astronoby, main library using Ephem at the moment, so it feels right to support their ephemerides as well.

I am extremely lucky that they offer a SPICE version of their ephemeris files for most of INPOP's versions. As you can see, this change doesn't implement any modification of the SPK parsing logic, it only adds the support for downloading files from somewhere else than the JPL.

The choice between JPL and IMCCE is just a matter of preference, their data being extremely close. While you can witness differences of a few kilometers in positions, the difference becomes barely noticeable when used in libraries transforming the data into topocentric coordinates like Astronoby.

The list of supported files is:
* `inpop10b.bsp`
* `inpop10b_large.bsp`
* `inpop10e.bsp`
* `inpop10e_large.bsp`
* `inpop13c.bsp`
* `inpop13c_large.bsp`
* `inpop17a.bsp`
* `inpop17a_large.bsp`
* `inpop19a.bsp`
* `inpop19a_large.bsp`
* `inpop21a.bsp`
* `inpop21a_large`

The difference between ephemerides with or without `_large` is the time period: from 1900 to 2100 for regular ephemerides, from 1000 to 3000, Common Era.