### PR TITLE
Use alias methods to get segment position or state

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ puts segment.describe(verbose: true)
 # Get the position and velocity of the target body at a given time
 # The time is expressed in Julian Date
 time = 2460676.5
-state = segment.compute_and_differentiate(time)
+state = segment.state_at(time)
 
 # Display the position and velocity vectors
 puts "Position: #{state.position}"

--- a/lib/ephem/segments/segment.rb
+++ b/lib/ephem/segments/segment.rb
@@ -71,6 +71,7 @@ module Ephem
       def compute(tdb, tdb2 = 0.0)
         Core::Vector.new(*generate(tdb, tdb2).first)
       end
+      alias_method :position_at, :compute
 
       # Computes both position and velocity vectors at the specified time.
       #
@@ -109,6 +110,7 @@ module Ephem
           end
         end
       end
+      alias_method :state_at, :compute_and_differentiate
 
       # Clears cached coefficient data, forcing reload on next computation.
       #

--- a/spec/ephem/excerpt_spec.rb
+++ b/spec/ephem/excerpt_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe Ephem::Excerpt do
       )
       original_segment = original_spk[center, target]
       excerpt_segment = excerpt_spk[center, target]
-      original_state = original_segment.compute_and_differentiate(test_time)
-      excerpt_state = excerpt_segment.compute_and_differentiate(test_time)
+      original_state = original_segment.state_at(test_time)
+      excerpt_state = excerpt_segment.state_at(test_time)
 
       expect(excerpt_state.position.to_a).to eq original_state.position.to_a
       expect(excerpt_state.velocity.to_a).to eq original_state.velocity.to_a


### PR DESCRIPTION
Before, the method responsible for getting a position vector from a segment was `#compute`, and the one to get a state was `#compute_and_differentiate`.

Now, alias methods `#position_at` and `#state_at` are added for readability.