### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.3.0] - 2025-04-30
+
+## Features
+
+* Improve find_interval with binary search ([#24])
+* Use alias methods to get segment position or state ([#27])
+
+## Improvements
+
+* Bump irb from 1.15.1 to 1.15.2 by @dependabot ([#21])
+* Bump standard from 1.47.0 to 1.49.0 by @dependabot ([#23])
+* Bump csv from 3.3.3 to 3.3.4 by @dependabot ([#25])
+* Bump parallel from 1.26.3 to 1.27.0 by @dependabot ([#26])
+
+**Full Changelog**: https://github.com/rhannequin/ruby-ephem/compare/v0.2.0...v0.3.0
+
+[#21]: https://github.com/rhannequin/ruby-ephem/pull/21
+[#23]: https://github.com/rhannequin/ruby-ephem/pull/23
+[#24]: https://github.com/rhannequin/ruby-ephem/pull/24
+[#25]: https://github.com/rhannequin/ruby-ephem/pull/25
+[#26]: https://github.com/rhannequin/ruby-ephem/pull/26
+[#27]: https://github.com/rhannequin/ruby-ephem/pull/27
+
 ## [0.2.0] - 2025-03-28
 
 ### Features

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ephem (0.2.0)
+    ephem (0.3.0)
       minitar (~> 0.12)
       numo-narray (~> 0.9.2.1)
       zlib (~> 3.2)

--- a/ephem.gemspec
+++ b/ephem.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.authors = ["Rémy Hannequin"]
   spec.email = ["remy.hannequin@gmail.com"]
 
-  spec.summary = "Compute astronomical ephemerides from NASA JPL Development Ephemerides"
-  spec.description = "Ruby implementation of the parsing and computation of ephemerides from NASA JPL Development Ephemerides DE4xx"
+  spec.summary = "Compute astronomical ephemerides from NASA/JPL DE and IMCCE INPOP"
+  spec.description = "Ruby implementation of the parsing and computation of ephemerides from NASA/JPL Development Ephemerides DE4xx and IMCCE INPOP"
   spec.homepage = "https://github.com/rhannequin/ruby-ephem"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.0.0"

--- a/lib/ephem/version.rb
+++ b/lib/ephem/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ephem
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
## Features

* Improve find_interval with binary search ([#24])
* Use alias methods to get segment position or state ([#27])

## Improvements

* Bump irb from 1.15.1 to 1.15.2 by @dependabot ([#21])
* Bump standard from 1.47.0 to 1.49.0 by @dependabot ([#23])
* Bump csv from 3.3.3 to 3.3.4 by @dependabot ([#25])
* Bump parallel from 1.26.3 to 1.27.0 by @dependabot ([#26])


**Full Changelog**: https://github.com/rhannequin/ruby-ephem/compare/v0.2.0...v0.3.0

[#21]: https://github.com/rhannequin/ruby-ephem/pull/21
[#23]: https://github.com/rhannequin/ruby-ephem/pull/23
[#24]: https://github.com/rhannequin/ruby-ephem/pull/24
[#25]: https://github.com/rhannequin/ruby-ephem/pull/25
[#26]: https://github.com/rhannequin/ruby-ephem/pull/26
[#27]: https://github.com/rhannequin/ruby-ephem/pull/27
