### PR TITLE
Write downloaded ephemeris in binary mode

### DIFF
--- a/lib/ephem/download.rb
+++ b/lib/ephem/download.rb
@@ -102,7 +102,7 @@ module Ephem
 
     def call
       content = jpl_kernel? ? download_from_jpl : download_from_imcce
-      File.write(@local_path, content)
+      File.binwrite(@local_path, content)
 
       true
     end

--- a/spec/ephem/download_spec.rb
+++ b/spec/ephem/download_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Ephem::Download do
         target_path = "tmp/kernel.bsp"
         mock_content = "large-binary-data"
         allow(Net::HTTP).to receive(:get).and_return(mock_content)
-        allow(File).to receive(:write)
+        allow(File).to receive(:binwrite)
 
         described_class.call(name: name, target: target_path)
 
-        expect(File).to have_received(:write).with(target_path, mock_content)
+        expect(File).to have_received(:binwrite).with(target_path, mock_content)
       end
     end
 
@@ -23,11 +23,11 @@ RSpec.describe Ephem::Download do
         mock_content = "large-binary-data"
         tar_gz_file = create_temp_tar_gz_with(name => mock_content)
         allow(Net::HTTP).to receive(:get).and_return(tar_gz_file.read)
-        allow(File).to receive(:write)
+        allow(File).to receive(:binwrite)
 
         described_class.call(name: name, target: target_path)
 
-        expect(File).to have_received(:write).with(target_path, mock_content)
+        expect(File).to have_received(:binwrite).with(target_path, mock_content)
       end
     end
 


### PR DESCRIPTION
Before, the ephemeris file was stored locally using `File.write`.

`.bsp` files are binary ones, therefore they should be written using `File.binwrite` instead.

Fixes #30