### PR TITLE
v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.3.1] - 2025-05-16
+
+### Bug fixes
+
+* Write downloaded ephemeris in binary mode by @trevorturk ([#31])
+
+### Improvements
+
+* Bump standard from 1.49.0 to 1.50.0 by @dependabot ([#29])
+
+### New Contributors
+
+* @trevorturk made their first contribution in [#31]
+
+**Full Changelog**: https://github.com/rhannequin/ruby-ephem/compare/v0.3.0...v0.3.1
+
+[#29]: https://github.com/rhannequin/ruby-ephem/pull/29
+[#31]: https://github.com/rhannequin/ruby-ephem/pull/31
+
 ## [0.3.0] - 2025-04-30
 
 ## Features

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ephem (0.3.0)
+    ephem (0.3.1)
       minitar (~> 0.12)
       numo-narray (~> 0.9.2.1)
       zlib (~> 3.2)

--- a/lib/ephem/version.rb
+++ b/lib/ephem/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ephem
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
## [0.3.1] - 2025-05-16

### Bug fixes

* Write downloaded ephemeris in binary mode by @trevorturk ([#31])

### Improvements

* Bump standard from 1.49.0 to 1.50.0 by @dependabot ([#29])

### New Contributors

* @trevorturk made their first contribution in [#31]

**Full Changelog**: https://github.com/rhannequin/ruby-ephem/compare/v0.3.0...v0.3.1

[#29]: https://github.com/rhannequin/ruby-ephem/pull/29
[#31]: https://github.com/rhannequin/ruby-ephem/pull/31
