### PR TITLE
Improve Chebyshev polynomial performance

### DIFF
--- a/lib/ephem/computation/chebyshev_polynomial.rb
+++ b/lib/ephem/computation/chebyshev_polynomial.rb
@@ -1,192 +1,89 @@
 # frozen_string_literal: true
 
-require "numo/narray"
-
 module Ephem
   module Computation
-    # Implements Chebyshev polynomial evaluation and differentiation for
-    # astronomical calculations.
+    ##
+    # High-performance, three-dimensional Clenshaw evaluation and derivative
+    # evaluation for Chebyshev polynomials, as used in SPK ephemerides.
     #
-    # Chebyshev polynomials are mathematical functions that can be used to
-    # approximate other functions with high accuracy. In astronomical
-    # calculations, they are used to approximate positions and velocities of
-    # celestial bodies.
+    # @see https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/cheby.html
+    # @see https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/spicelib/spkche.html
     #
-    # The polynomial evaluation is done using the Clenshaw algorithm, which is
-    # numerically stable and efficient. For performance optimization, polynomial
-    # values are cached when they need to be used both for position and velocity
-    # calculations.
-    #
-    # @example Calculating position in 3D space
-    #   # coefficients is a 2D array where:
-    #   # - First dimension is the polynomial degree (n terms)
-    #   # - Second dimension is the spatial dimension (3 for x,y,z)
-    #   coefficients = Numo::DFloat.cast([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-    #
-    #   # normalized_time must be between -1 and 1
-    #   polynomial = ChebyshevPolynomial.new(
-    #     coefficients: coefficients,
-    #     normalized_time: 0.5
-    #   )
-    #
-    #   position = polynomial.evaluate
-    #
-    # @example Calculating velocity with time scaling
-    #   # radius is the time span in days
-    #   polynomial = ChebyshevPolynomial.new(
-    #     coefficients: coefficients,
-    #     normalized_time: 0.5,
-    #     radius: 32.0  # 32-day time span
-    #   )
-    #
-    #   velocity = polynomial.evaluate_derivative
-    class ChebyshevPolynomial
-      include Core::Constants::Time
-
-      # Initializes a new Chebyshev polynomial calculator
+    module ChebyshevPolynomial
+      ##
+      # Evaluates a 3D Chebyshev polynomial at a given normalized time.
       #
-      # @param coefficients [Numo::NArray] 2D array of Chebyshev polynomial
-      #   coefficients. First dimension represents polynomial terms
-      #   (degree + 1). Second dimension represents spatial components
-      #   (usually 3 for x,y,z)
-      # @param normalized_time [Float] Time parameter normalized to [-1, 1]
-      #   interval
-      # @param radius [Float, nil] Optional scaling factor for derivative
-      #   calculations, usually represents the time span of the interval in days
-      #
-      # @raise [Ephem::InvalidInputError] if coefficients are not a 2D
-      #   Numo::NArray
-      # @raise [Ephem::InvalidInputError] if normalized_time is outside [-1, 1]
-      def initialize(coefficients:, normalized_time:, radius: nil)
-        validate_inputs(coefficients, normalized_time)
+      # @param coeffs [Array<Array<Float>>] Array of coefficients; shape is
+      #   [n_terms][3].
+      # @param t [Float] The normalized independent variable, in [-1, 1].
+      # @return [Array<Float>] The 3-vector result at t: [x, y, z]
+      def self.evaluate(coeffs, t)
+        n = coeffs.size
+        b1x = b1y = b1z = 0.0
+        b2x = b2y = b2z = 0.0
 
-        @coefficients = coefficients
-        @normalized_time = normalized_time
-        @radius = radius
-        @degree = @coefficients.shape[0]
-        @dimension = @coefficients.shape[1]
-        @two_times_normalized_time = 2.0 * @normalized_time
-        @polynomials = nil # Cache for polynomial values
-      end
-
-      # Evaluates the Chebyshev polynomial at the normalized time point
-      #
-      # Uses the Clenshaw algorithm for numerical stability. The algorithm
-      # evaluates the polynomial using a recurrence relation, which is more
-      # stable than direct power series evaluation.
-      #
-      # @return [Numo::DFloat] Evaluation result, array of size dimension
-      #   (usually 3)
-      def evaluate
-        @polynomials ||= generate_polynomials(@degree, @dimension)
-        combine_polynomials(@polynomials)
-      end
-
-      # Calculates the derivative of the Chebyshev polynomial
-      #
-      # For astronomical calculations, this typically represents velocity.
-      # For polynomials of degree < 2, returns zero array since the derivative
-      # of constants and linear terms are constant or zero.
-      #
-      # If radius is provided, scales the result to convert from normalized time
-      # units to physical units (usually km/sec in astronomical calculations)
-      #
-      # @return [Numo::DFloat] Derivative values, array of size dimension
-      #   (usually 3)
-      def evaluate_derivative
-        return Numo::DFloat.zeros(@dimension) if @degree < 2
-
-        derivative = calculate_derivative(@degree, @dimension)
-        scale_derivative(derivative)
-      end
-
-      private
-
-      def validate_inputs(coefficients, normalized_time)
-        unless coefficients.is_a?(Numo::NArray) && coefficients.ndim == 2
-          raise InvalidInputError, "Coefficients must be a 2D Numo::NArray"
+        k = n - 1
+        while k > 0
+          c = coeffs[k]
+          c0 = c[0]
+          c1 = c[1]
+          c2 = c[2]
+          t2 = 2.0 * t
+          tx = t2 * b1x - b2x + c0
+          ty = t2 * b1y - b2y + c1
+          tz = t2 * b1z - b2z + c2
+          b2x = b1x
+          b2y = b1y
+          b2z = b1z
+          b1x = tx
+          b1y = ty
+          b1z = tz
+          k -= 1
         end
 
-        unless (-1.0..1.0).cover?(normalized_time)
-          raise InvalidInputError, "Normalized time must be in range [-1, 1]"
-        end
+        c0, c1, c2 = coeffs[0]
+        [t * b1x - b2x + c0, t * b1y - b2y + c1, t * b1z - b2z + c2]
       end
 
-      # Generates the sequence of Chebyshev polynomials
-      # Uses the recurrence relation for Chebyshev polynomials:
-      # T₀(x) = 1
-      # T₁(x) = x
-      # Tₙ₊₁(x) = 2xTₙ(x) - Tₙ₋₁(x)
-      def generate_polynomials(degree, dimension)
-        polynomials = initialize_base_polynomials(dimension)
-        return polynomials if degree <= 2
+      ##
+      # Evaluates the time derivative of a 3D Chebyshev polynomial at a given
+      # normalized time.
+      #
+      # @param coeffs [Array<Array<Float>>] Array of coefficients; shape is
+      #   [n_terms][3].
+      # @param t [Float] The normalized independent variable (in [-1, 1]).
+      # @param radius [Float] The half-length of the time interval (days).
+      # @return [Array<Float>] The 3-vector derivative (velocity), in units per
+      #   second.
+      def self.evaluate_derivative(coeffs, t, radius)
+        n = coeffs.size
+        return [0.0, 0.0, 0.0] if n < 2
 
-        build_polynomial_sequence(polynomials, degree)
-        polynomials
-      end
+        d1x = d1y = d1z = 0.0
+        d2x = d2y = d2z = 0.0
 
-      # Initializes T₀(x) = 1 and T₁(x) = x polynomials
-      def initialize_base_polynomials(dimension)
-        [
-          Numo::DFloat.ones(dimension),
-          @normalized_time * Numo::DFloat.ones(dimension)
-        ]
-      end
-
-      def build_polynomial_sequence(polynomials, degree)
-        (2...degree).each do |i|
-          polynomials << compute_next_polynomial(
-            polynomials[i - 2],
-            polynomials[i - 1]
-          )
-        end
-      end
-
-      def compute_next_polynomial(prev_prev, prev)
-        @two_times_normalized_time * prev - prev_prev
-      end
-
-      # Combines polynomials with their coefficients
-      # Uses vectorized operations for efficiency. The final result is:
-      # Σ(coefficients[i] * polynomials[i]) for i from 0 to degree-1
-      def combine_polynomials(polynomials)
-        (0...@degree).inject(Numo::DFloat.zeros(@dimension)) do |result, i|
-          result + @coefficients[i, true] * polynomials[i]
-        end
-      end
-
-      # Calculates derivative using the modified Clenshaw algorithm
-      # The algorithm is adapted to compute derivatives of Chebyshev polynomials
-      # while maintaining numerical stability
-      def calculate_derivative(degree, dimension)
-        @polynomials ||= generate_polynomials(degree, dimension)
-
-        derivative_prev = Numo::DFloat.zeros(dimension)
-        derivative = derivative_prev.clone
-
-        (degree - 1).downto(1) do |i|
-          derivative_next = derivative.clone
-          derivative = derivative_prev
-          derivative_prev = calculate_derivative_term(
-            i,
-            derivative,
-            derivative_next
-          )
+        k = n - 1
+        while k > 0
+          c = coeffs[k]
+          c0 = c[0]
+          c1 = c[1]
+          c2 = c[2]
+          t2 = 2.0 * t
+          k2 = 2 * k
+          tx = t2 * d1x - d2x + k2 * c0
+          ty = t2 * d1y - d2y + k2 * c1
+          tz = t2 * d1z - d2z + k2 * c2
+          d2x = d1x
+          d2y = d1y
+          d2z = d1z
+          d1x = tx
+          d1y = ty
+          d1z = tz
+          k -= 1
         end
 
-        derivative_prev
-      end
-
-      def calculate_derivative_term(index, deriv, deriv_next)
-        @two_times_normalized_time * deriv -
-          deriv_next +
-          @coefficients[index, true] * 2 * index
-      end
-
-      def scale_derivative(derivative)
-        return derivative unless @radius
-
-        derivative * (SECONDS_PER_DAY / (2.0 * @radius))
+        scale = Ephem::Core::Constants::Time::SECONDS_PER_DAY / (2.0 * radius)
+        [d1x * scale, d1y * scale, d1z * scale]
       end
     end
   end

--- a/spec/ephem/computation/chebyshev_polynomial_spec.rb
+++ b/spec/ephem/computation/chebyshev_polynomial_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Ephem::Computation::ChebyshevPolynomial do
         coeffs = [[1.0, 2.0, 3.0]]
         t = 0.123
 
-        polynomial = described_class.evaluate(coeffs, t)
+        result = described_class.evaluate(coeffs, t)
 
-        expect(polynomial).to eq([1.0, 2.0, 3.0])
+        expect(result).to eq([1.0, 2.0, 3.0])
       end
     end
 
@@ -26,9 +26,9 @@ RSpec.describe Ephem::Computation::ChebyshevPolynomial do
           -2.0 + 0.0 * 0.75
         ]
 
-        polynomial = described_class.evaluate(coeffs, t)
+        result = described_class.evaluate(coeffs, t)
 
-        expect_vector_close(polynomial, expected)
+        expect_vector_close(result, expected)
       end
     end
 
@@ -49,9 +49,9 @@ RSpec.describe Ephem::Computation::ChebyshevPolynomial do
           coeffs[0][2] * t0 + coeffs[1][2] * t1 + coeffs[2][2] * t2
         ]
 
-        polynomial = described_class.evaluate(coeffs, t)
+        result = described_class.evaluate(coeffs, t)
 
-        expect_vector_close(polynomial, expected)
+        expect_vector_close(result, expected)
       end
     end
 
@@ -65,9 +65,9 @@ RSpec.describe Ephem::Computation::ChebyshevPolynomial do
         ]
         t = 0.333
 
-        polynomial = described_class.evaluate(coeffs, t)
+        result = described_class.evaluate(coeffs, t)
 
-        expect(polynomial.size).to eq(3)
+        expect(result.size).to eq(3)
       end
     end
 
@@ -79,10 +79,10 @@ RSpec.describe Ephem::Computation::ChebyshevPolynomial do
       ]
       t = 0.62
 
-      out1 = described_class.evaluate(coeffs, t)
-      out2 = described_class.evaluate(coeffs, t)
+      result1 = described_class.evaluate(coeffs, t)
+      result2 = described_class.evaluate(coeffs, t)
 
-      expect(out1).to eq(out2)
+      expect(result1).to eq(result2)
     end
 
     it "returns different results for different normalized_time" do
@@ -91,10 +91,10 @@ RSpec.describe Ephem::Computation::ChebyshevPolynomial do
         [0.1, 0.05, -0.09]
       ]
 
-      out1 = described_class.evaluate(coeffs, 0.9)
-      out2 = described_class.evaluate(coeffs, -0.9)
+      result1 = described_class.evaluate(coeffs, 0.9)
+      result2 = described_class.evaluate(coeffs, -0.9)
 
-      expect(out1).not_to eq(out2)
+      expect(result1).not_to eq(result2)
     end
   end
 
@@ -105,9 +105,9 @@ RSpec.describe Ephem::Computation::ChebyshevPolynomial do
         t = -0.2
         radius = 1000.0
 
-        polynomial = described_class.evaluate_derivative(coeffs, t, radius)
+        result = described_class.evaluate_derivative(coeffs, t, radius)
 
-        expect(polynomial).to eq([0.0, 0.0, 0.0])
+        expect(result).to eq([0.0, 0.0, 0.0])
       end
     end
 
@@ -122,9 +122,9 @@ RSpec.describe Ephem::Computation::ChebyshevPolynomial do
         scale = Ephem::Core::Constants::Time::SECONDS_PER_DAY / (2.0 * radius)
         expected = [2 * 2.0 * scale, 2 * -1.5 * scale, 2 * 4.0 * scale]
 
-        polynomial = described_class.evaluate_derivative(coeffs, t, radius)
+        result = described_class.evaluate_derivative(coeffs, t, radius)
 
-        expect_vector_close(polynomial, expected)
+        expect_vector_close(result, expected)
       end
     end
 
@@ -138,9 +138,9 @@ RSpec.describe Ephem::Computation::ChebyshevPolynomial do
         t = 0.15
         radius = 2000.0
 
-        polynomial = described_class.evaluate_derivative(coeffs, t, radius)
+        result = described_class.evaluate_derivative(coeffs, t, radius)
 
-        expect(polynomial.size).to eq(3)
+        expect(result.size).to eq(3)
       end
     end
 
@@ -153,10 +153,10 @@ RSpec.describe Ephem::Computation::ChebyshevPolynomial do
       radius1 = 1000.0
       radius2 = 500.0
 
-      polynomial1 = described_class.evaluate_derivative(coeffs, t, radius1)
-      polynomial2 = described_class.evaluate_derivative(coeffs, t, radius2)
+      result1 = described_class.evaluate_derivative(coeffs, t, radius1)
+      result2 = described_class.evaluate_derivative(coeffs, t, radius2)
 
-      expect(polynomial1).not_to eq(polynomial2)
+      expect(result1).not_to eq(result2)
     end
 
     it "returns the same result for repeated calls" do
@@ -168,10 +168,10 @@ RSpec.describe Ephem::Computation::ChebyshevPolynomial do
       t = 0.58
       radius = 432.0
 
-      polynomial1 = described_class.evaluate_derivative(coeffs, t, radius)
-      polynomial2 = described_class.evaluate_derivative(coeffs, t, radius)
+      result1 = described_class.evaluate_derivative(coeffs, t, radius)
+      result2 = described_class.evaluate_derivative(coeffs, t, radius)
 
-      expect(polynomial1).to eq(polynomial2)
+      expect(result1).to eq(result2)
     end
 
     it "returns different results for different normalized_time" do
@@ -184,10 +184,10 @@ RSpec.describe Ephem::Computation::ChebyshevPolynomial do
       t2 = -0.3
       radius = 111.1
 
-      polynomial1 = described_class.evaluate_derivative(coeffs, t, radius)
-      polynomial2 = described_class.evaluate_derivative(coeffs, t2, radius)
+      result1 = described_class.evaluate_derivative(coeffs, t, radius)
+      result2 = described_class.evaluate_derivative(coeffs, t2, radius)
 
-      expect(polynomial1).not_to eq(polynomial2)
+      expect(result1).not_to eq(result2)
     end
   end
 

--- a/spec/ephem/computation/chebyshev_polynomial_spec.rb
+++ b/spec/ephem/computation/chebyshev_polynomial_spec.rb
@@ -1,225 +1,200 @@
 # frozen_string_literal: true
 
 RSpec.describe Ephem::Computation::ChebyshevPolynomial do
-  describe "#initialize" do
-    it "raises error for non-NArray coefficients" do
-      expect do
-        described_class.new(
-          coefficients: [[1, 1, 1]],
-          normalized_time: 0.5
-        )
-      end.to raise_error(
-        Ephem::InvalidInputError,
-        "Coefficients must be a 2D Numo::NArray"
-      )
-    end
+  describe ".evaluate" do
+    context "with degree 1 (constant only)" do
+      it "returns the constant vector" do
+        coeffs = [[1.0, 2.0, 3.0]]
+        t = 0.123
 
-    it "raises error for 1D coefficients" do
-      expect do
-        described_class.new(
-          coefficients: Numo::DFloat.cast([1, 1, 1]),
-          normalized_time: 0.5
-        )
-      end.to raise_error(
-        Ephem::InvalidInputError,
-        "Coefficients must be a 2D Numo::NArray"
-      )
-    end
+        polynomial = described_class.evaluate(coeffs, t)
 
-    it "raises error for normalized_time below -1" do
-      coefficients = Numo::DFloat.cast([[1.0, 1.0, 1.0]])
-
-      expect do
-        described_class.new(
-          coefficients: coefficients,
-          normalized_time: -1.1
-        )
-      end.to raise_error(
-        Ephem::InvalidInputError,
-        "Normalized time must be in range [-1, 1]"
-      )
-    end
-
-    it "raises error for normalized_time above 1" do
-      coefficients = Numo::DFloat.cast([[1.0, 1.0, 1.0]])
-
-      expect do
-        described_class.new(
-          coefficients: coefficients,
-          normalized_time: 1.1
-        )
-      end.to raise_error(
-        Ephem::InvalidInputError,
-        "Normalized time must be in range [-1, 1]"
-      )
-    end
-  end
-
-  describe "#evaluate" do
-    context "with degree 1" do
-      it "returns correct evaluation for constant polynomial" do
-        coefficients = Numo::DFloat.cast([[1.0, 1.0, 1.0]])
-        polynomial = described_class.new(
-          coefficients: coefficients,
-          normalized_time: 0.5
-        )
-
-        result = polynomial.evaluate
-
-        expect(result).to be_a(Numo::DFloat)
-        expect(result.shape[0]).to eq(3)
-        expect(result).to eq(Numo::DFloat[1.0, 1.0, 1.0])
+        expect(polynomial).to eq([1.0, 2.0, 3.0])
       end
     end
 
-    context "with degree 2" do
-      it "returns correct evaluation for linear polynomial" do
-        coefficients = Numo::DFloat.cast([
-          [1.0, 1.0, 1.0],
-          [2.0, 2.0, 2.0]
-        ])
-        polynomial = described_class.new(
-          coefficients: coefficients,
-          normalized_time: 0.5
-        )
+    context "with degree 2 (constant + linear)" do
+      it "returns componentwise a0 + t*a1" do
+        coeffs = [
+          [1.0, 5.0, -2.0],
+          [2.0, 1.5, 0.0]
+        ]
+        t = 0.75
+        expected = [
+          1.0 + 2.0 * 0.75,
+          5.0 + 1.5 * 0.75,
+          -2.0 + 0.0 * 0.75
+        ]
 
-        result = polynomial.evaluate
+        polynomial = described_class.evaluate(coeffs, t)
 
-        expected = coefficients[0, true] + coefficients[1, true] * 0.5
-        expect(result).to be_within(1e-10).of(expected)
+        expect_vector_close(polynomial, expected)
       end
     end
 
-    context "with higher degree polynomials" do
-      it "returns result with correct shape" do
-        coefficients = Numo::DFloat.cast([
-          [1.0, 1.0, 1.0],
-          [2.0, 2.0, 2.0],
-          [3.0, 3.0, 3.0]
-        ])
-        polynomial = described_class.new(
-          coefficients: coefficients,
-          normalized_time: 0.5
-        )
+    context "with degree 3 (quadratic)" do
+      it "matches explicit sum a0*T0 + a1*T1 + a2*T2" do
+        coeffs = [
+          [1.0, 2.0, 3.0],
+          [4.0, 0.5, 0.0],
+          [-1.0, 2.0, 1.5]
+        ]
+        t = -0.2
+        t0 = 1
+        t1 = t
+        t2 = 2 * t * t - 1
+        expected = [
+          coeffs[0][0] * t0 + coeffs[1][0] * t1 + coeffs[2][0] * t2,
+          coeffs[0][1] * t0 + coeffs[1][1] * t1 + coeffs[2][1] * t2,
+          coeffs[0][2] * t0 + coeffs[1][2] * t1 + coeffs[2][2] * t2
+        ]
 
-        result = polynomial.evaluate
+        polynomial = described_class.evaluate(coeffs, t)
 
-        expect(result).to be_a(Numo::DFloat)
-        expect(result.shape[0]).to eq(3)
+        expect_vector_close(polynomial, expected)
       end
+    end
 
-      it "returns consistent results on multiple evaluations" do
-        coefficients = Numo::DFloat.cast([
-          [1.0, 1.0, 1.0],
-          [2.0, 2.0, 2.0],
-          [3.0, 3.0, 3.0]
-        ])
-        polynomial = described_class.new(
-          coefficients: coefficients,
-          normalized_time: 0.5
-        )
+    context "with longer coefficients array" do
+      it "returns array of size 3" do
+        coeffs = [
+          [1.0, 2.0, 3.0],
+          [4.0, 5.0, 6.0],
+          [7.0, 8.0, 9.0],
+          [2.0, 1.0, 0.0]
+        ]
+        t = 0.333
 
-        first_result = polynomial.evaluate
-        second_result = polynomial.evaluate
+        polynomial = described_class.evaluate(coeffs, t)
 
-        expect(first_result).to eq(second_result)
+        expect(polynomial.size).to eq(3)
       end
+    end
 
-      it "returns different results for different normalized times" do
-        coefficients = Numo::DFloat.cast([
-          [1.0, 1.0, 1.0],
-          [2.0, 2.0, 2.0],
-          [3.0, 3.0, 3.0]
-        ])
+    it "returns the same result for repeated calls" do
+      coeffs = [
+        [0.2, 1.5, 3.7],
+        [0.3, -0.1, 0.4],
+        [1.0, -0.5, -0.75]
+      ]
+      t = 0.62
 
-        result1 = described_class.new(
-          coefficients: coefficients,
-          normalized_time: 0.5
-        ).evaluate
-        result2 = described_class.new(
-          coefficients: coefficients,
-          normalized_time: 0.6
-        ).evaluate
+      out1 = described_class.evaluate(coeffs, t)
+      out2 = described_class.evaluate(coeffs, t)
 
-        expect(result1).not_to eq(result2)
-      end
+      expect(out1).to eq(out2)
+    end
+
+    it "returns different results for different normalized_time" do
+      coeffs = [
+        [2.0, 1.0, -1.0],
+        [0.1, 0.05, -0.09]
+      ]
+
+      out1 = described_class.evaluate(coeffs, 0.9)
+      out2 = described_class.evaluate(coeffs, -0.9)
+
+      expect(out1).not_to eq(out2)
     end
   end
 
-  describe "#evaluate_derivative" do
-    context "with degree < 2" do
-      it "returns zero array" do
-        coefficients = Numo::DFloat.cast([[1.0, 1.0, 1.0]])
-        polynomial = described_class.new(
-          coefficients: coefficients,
-          normalized_time: 0.5,
-          radius: 1000.0
-        )
+  describe ".evaluate_derivative" do
+    context "with degree 1 (constant only)" do
+      it "returns zero vector" do
+        coeffs = [[1.0, 2.0, 3.0]]
+        t = -0.2
+        radius = 1000.0
 
-        result = polynomial.evaluate_derivative
+        polynomial = described_class.evaluate_derivative(coeffs, t, radius)
 
-        expect(result).to eq(Numo::DFloat.zeros(3))
+        expect(polynomial).to eq([0.0, 0.0, 0.0])
       end
     end
 
-    context "with degree >= 2" do
-      it "returns result with correct shape" do
-        coefficients = Numo::DFloat.cast([
-          [1.0, 1.0, 1.0],
-          [2.0, 2.0, 2.0],
-          [3.0, 3.0, 3.0]
-        ])
-        polynomial = described_class.new(
-          coefficients: coefficients,
-          normalized_time: 0.5,
-          radius: 1000.0
-        )
+    context "with degree 2 (constant + linear)" do
+      it "returns 2*a1 * scale" do
+        coeffs = [
+          [0.0, 0.0, 0.0],
+          [2.0, -1.5, 4.0]
+        ]
+        t = 0.0
+        radius = 123.0
+        scale = Ephem::Core::Constants::Time::SECONDS_PER_DAY / (2.0 * radius)
+        expected = [2 * 2.0 * scale, 2 * -1.5 * scale, 2 * 4.0 * scale]
 
-        result = polynomial.evaluate_derivative
+        polynomial = described_class.evaluate_derivative(coeffs, t, radius)
 
-        expect(result).to be_a(Numo::DFloat)
-        expect(result.shape[0]).to eq(3)
+        expect_vector_close(polynomial, expected)
       end
+    end
 
-      it "returns consistent derivative results when evaluating multiple times" do
-        coefficients = Numo::DFloat.cast([
-          [1.0, 1.0, 1.0],
-          [2.0, 2.0, 2.0],
-          [3.0, 3.0, 3.0]
-        ])
-        polynomial = described_class.new(
-          coefficients: coefficients,
-          normalized_time: 0.5,
-          radius: 1000.0
-        )
+    context "with degree 3 (quadratic)" do
+      it "computes correct Chebyshev derivative" do
+        coeffs = [
+          [1.0, 2.0, 3.0],
+          [0.5, 0.2, -1.5],
+          [-0.25, 1.0, 2.0]
+        ]
+        t = 0.15
+        radius = 2000.0
 
-        polynomial.evaluate
-        first_derivative = polynomial.evaluate_derivative
-        second_derivative = polynomial.evaluate_derivative
+        polynomial = described_class.evaluate_derivative(coeffs, t, radius)
 
-        expect(first_derivative).to eq(second_derivative)
+        expect(polynomial.size).to eq(3)
       end
+    end
 
-      it "scales derivative with radius" do
-        coefficients = Numo::DFloat.cast([
-          [1.0, 1.0, 1.0],
-          [2.0, 2.0, 2.0],
-          [3.0, 3.0, 3.0]
-        ])
+    it "scales velocity according to radius" do
+      coeffs = [
+        [0.0, 0.0, 0.0],
+        [2.0, -2.0, 4.0]
+      ]
+      t = 0.25
+      radius1 = 1000.0
+      radius2 = 500.0
 
-        result_with_radius = described_class.new(
-          coefficients: coefficients,
-          normalized_time: 0.5,
-          radius: 1000.0
-        ).evaluate_derivative
-        result_without_radius = described_class.new(
-          coefficients: coefficients,
-          normalized_time: 0.5,
-          radius: nil
-        ).evaluate_derivative
+      polynomial1 = described_class.evaluate_derivative(coeffs, t, radius1)
+      polynomial2 = described_class.evaluate_derivative(coeffs, t, radius2)
 
-        expect(result_with_radius).not_to eq(result_without_radius)
-      end
+      expect(polynomial1).not_to eq(polynomial2)
+    end
+
+    it "returns the same result for repeated calls" do
+      coeffs = [
+        [1.1, -0.1, 0.5],
+        [0.0, 2.0, -2.0],
+        [0.5, -1.0, 3.0]
+      ]
+      t = 0.58
+      radius = 432.0
+
+      polynomial1 = described_class.evaluate_derivative(coeffs, t, radius)
+      polynomial2 = described_class.evaluate_derivative(coeffs, t, radius)
+
+      expect(polynomial1).to eq(polynomial2)
+    end
+
+    it "returns different results for different normalized_time" do
+      coeffs = [
+        [2.0, 1.0, -1.0],
+        [0.1, 0.05, -0.09],
+        [0.2, -0.7, 0.5]
+      ]
+      t = 0.3
+      t2 = -0.3
+      radius = 111.1
+
+      polynomial1 = described_class.evaluate_derivative(coeffs, t, radius)
+      polynomial2 = described_class.evaluate_derivative(coeffs, t2, radius)
+
+      expect(polynomial1).not_to eq(polynomial2)
+    end
+  end
+
+  def expect_vector_close(result, expected, tol = 1e-10)
+    expect(result.size).to eq(expected.size)
+    result.zip(expected).each do |a, b|
+      expect(a).to be_within(tol).of(b)
     end
   end
 end


### PR DESCRIPTION
After a benchmark of the library, I found out Chebyshev polynomial evaluation part was the main pain point for performance.

**Full disclosure**, I am not great in math nor in pure computing science, so I used some AI models to help me figure out how to optimize the code. Therefore, the commit is under my name but I can't take credit for the great results I'm showing above.

I used the following naive script to evaluate the improvements step by step:

```rb
spk = Ephem::SPK.open("tmp/de440s.bsp")
segment = spk[0, 3]
start_time = Time.now

1000.times do
  (2460600..2460700).to_a.each { segment.state_at(_1) }
end

end_time = Time.now
puts "Executued in #{end_time - start_time} seconds"

{
  [0, 1, 2460676.500798611] => [[-58796391, -24211914, -6830870], [752900, -3248793, -1813402]],
  [0, 2, 2460707.500798611] => [[-21482794, 95084793, 44132081], [-2978557, -614137, -87841]],
  [0, 4, 2460766.500798611] => [[-214596103, 113040908, 57662718], [-991994, -1482459, -653195]],
  [0, 5, 2460796.500798611] => [[21224526, 703637652, 301087128], [-1141487, 68017, 56944]],
  [0, 6, 2460827.500798611] => [[1425287156, -107081764, -105619618], [35482, 766713, 315162]],
  [0, 7, 2460857.500798611] => [[1570711514, 2262283646, 968602638], [-500302, 262272, 121943]],
  [0, 8, 2460888.500798611] => [[4469473874, 45168128, -92786635], [-3571, 437248, 179057]]
}.each do |k, v|
  state = spk[k[0], k[1]].state_at(k[2])
  puts "Test with [#{k[0]},#{k[1]}] at #{k[2]} has correct position: #{state.position.to_a.map(&:round) == v[0]}"
  puts "Test with [#{k[0]},#{k[1]}] at #{k[2]} has correct velocity: #{state.velocity.to_a.map(&:round) == v[1]}"
end
```

All the values at the end were taken from the original code. I was also running the test suite in parallel.

When I started, with the original code, the output was:

```
Executued in 12.693311 seconds
Test with [0,1] at 2460676.500798611 has correct position: true
Test with [0,1] at 2460676.500798611 has correct velocity: true
Test with [0,2] at 2460707.500798611 has correct position: true
Test with [0,2] at 2460707.500798611 has correct velocity: true
Test with [0,4] at 2460766.500798611 has correct position: true
Test with [0,4] at 2460766.500798611 has correct velocity: true
Test with [0,5] at 2460796.500798611 has correct position: true
Test with [0,5] at 2460796.500798611 has correct velocity: true
Test with [0,6] at 2460827.500798611 has correct position: true
Test with [0,6] at 2460827.500798611 has correct velocity: true
Test with [0,7] at 2460857.500798611 has correct position: true
Test with [0,7] at 2460857.500798611 has correct velocity: true
Test with [0,8] at 2460888.500798611 has correct position: true
Test with [0,8] at 2460888.500798611 has correct velocity: true
```

With this change, the output is:

```
Executued in 0.674455 seconds
Test with [0,1] at 2460676.500798611 has correct position: true
Test with [0,1] at 2460676.500798611 has correct velocity: true
Test with [0,2] at 2460707.500798611 has correct position: true
Test with [0,2] at 2460707.500798611 has correct velocity: true
Test with [0,4] at 2460766.500798611 has correct position: true
Test with [0,4] at 2460766.500798611 has correct velocity: true
Test with [0,5] at 2460796.500798611 has correct position: true
Test with [0,5] at 2460796.500798611 has correct velocity: true
Test with [0,6] at 2460827.500798611 has correct position: true
Test with [0,6] at 2460827.500798611 has correct velocity: true
Test with [0,7] at 2460857.500798611 has correct position: true
Test with [0,7] at 2460857.500798611 has correct velocity: true
Test with [0,8] at 2460888.500798611 has correct position: true
Test with [0,8] at 2460888.500798611 has correct velocity: true
```

This represent a speed-up of more than 18 times (94.69% time decrease)!