### PR TITLE
Improve download file management

### DIFF
--- a/lib/ephem/download.rb
+++ b/lib/ephem/download.rb
@@ -128,7 +128,7 @@ module Ephem
     end
 
     def download_from_imcce
-      Tempfile.open(%w[ephem_kernel .tar.gz]) do |temp_file|
+      Tempfile.create(%w[ephem_kernel .tar.gz], unlink: true) do |temp_file|
         uri = URI.join(IMCCE_BASE_URL, IMCCE_KERNELS_MATCHING[@name])
         content = Net::HTTP.get(uri)
         temp_file.write(content)

--- a/lib/ephem/download.rb
+++ b/lib/ephem/download.rb
@@ -103,6 +103,7 @@ module Ephem
 
     def call
       content = jpl_kernel? ? download_from_jpl : download_from_imcce
+      FileUtils.mkdir_p(@target_path.dirname)
       @target_path.open("wb") { |f| f.write(content) }
 
       true

--- a/spec/ephem/download_spec.rb
+++ b/spec/ephem/download_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Ephem::Download do
         target_path = "tmp/kernel.bsp"
         mock_content = "large-binary-data"
         file_io = StringIO.new
-        pathname_double = instance_double(Pathname)
+        pathname_double = instance_double(Pathname, dirname: "tmp")
         allow(Net::HTTP).to receive(:get).and_return(mock_content)
         allow(Pathname).to receive(:new)
           .with(target_path)
@@ -31,7 +31,7 @@ RSpec.describe Ephem::Download do
         mock_content = "large-binary-data"
         tar_gz_file = create_temp_tar_gz_with(name => mock_content)
         file_io = StringIO.new
-        pathname_double = instance_double(Pathname)
+        pathname_double = instance_double(Pathname, dirname: "tmp")
         allow(Net::HTTP).to receive(:get).and_return(tar_gz_file.read)
         allow(Pathname).to receive(:new)
           .with(target_path)


### PR DESCRIPTION
This provides a better experience of downloading an ephemeris by using a more standard Ruby approach. It uses `Pathname`, which is common when dealing with file system.

Now, it supports `target` with usual UNIX-like format:

```rb
Ephem::Download.call(name: "inpop21a.bsp", target: "./inpop.bsp")
# Writes in the current directory

Ephem::Download.call(name: "inpop21a.bsp", target: "../inpop.bsp")
# Writes in the parent directory
```

It also now streams the HTTP response directly into the target file to reduce the memory footprint if the ephemeris is large.