### PR TITLE
v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.4.0] - 2025-06-09
+
+### Improvements
+
+* Improve Chebyshev polynomial performance ([#33])
+* Improve download file management ([#34])
+* Validate against all kernels and date ranges ([#36])
+* Add supported Ruby versions ([#35])
+* Bump rspec from 3.13.0 to 3.13.1 by @dependabot ([#38])
+* Bump rake from 13.2.1 to 13.3.0 by @dependabot ([#39])
+* Bump csv from 3.3.4 to 3.3.5 by @dependabot ([#40])
+
+[#33]: https://github.com/rhannequin/ruby-ephem/pull/33
+[#34]: https://github.com/rhannequin/ruby-ephem/pull/34
+[#35]: https://github.com/rhannequin/ruby-ephem/pull/35
+[#36]: https://github.com/rhannequin/ruby-ephem/pull/36
+[#38]: https://github.com/rhannequin/ruby-ephem/pull/38
+[#39]: https://github.com/rhannequin/ruby-ephem/pull/39
+[#40]: https://github.com/rhannequin/ruby-ephem/pull/40
+
+**Full Changelog**: https://github.com/rhannequin/ruby-ephem/compare/v0.3.1...v0.4.0
+
 ## [0.3.1] - 2025-05-16
 
 ### Bug fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ephem (0.3.1)
+    ephem (0.4.0)
       minitar (~> 0.12)
       numo-narray (~> 0.9.2.1)
       zlib (~> 3.2)

--- a/lib/ephem/version.rb
+++ b/lib/ephem/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ephem
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
## [0.4.0] - 2025-06-09

### Improvements

* Improve Chebyshev polynomial performance ([#33])
* Improve download file management ([#34])
* Validate against all kernels and date ranges ([#36])
* Add supported Ruby versions ([#35])
* Bump rspec from 3.13.0 to 3.13.1 by @dependabot ([#38])
* Bump rake from 13.2.1 to 13.3.0 by @dependabot ([#39])
* Bump csv from 3.3.4 to 3.3.5 by @dependabot ([#40])

[#33]: https://github.com/rhannequin/ruby-ephem/pull/33
[#34]: https://github.com/rhannequin/ruby-ephem/pull/34
[#35]: https://github.com/rhannequin/ruby-ephem/pull/35
[#36]: https://github.com/rhannequin/ruby-ephem/pull/36
[#38]: https://github.com/rhannequin/ruby-ephem/pull/38
[#39]: https://github.com/rhannequin/ruby-ephem/pull/39
[#40]: https://github.com/rhannequin/ruby-ephem/pull/40

**Full Changelog**: https://github.com/rhannequin/ruby-ephem/compare/v0.3.1...v0.4.0
