### PR TITLE
v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.4.1] - 2025-08-03
+
+### Improvements
+
+* Exclude BSP files from release ([#42])
+
+[#42]: https://github.com/rhannequin/ruby-ephem/pull/42
+
+**Full Changelog**: https://github.com/rhannequin/ruby-ephem/compare/v0.4.0...v0.4.1
+
 ## [0.4.0] - 2025-06-09
 
 ### Improvements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ephem (0.4.0)
+    ephem (0.4.1)
       minitar (~> 0.12)
       numo-narray (~> 0.9.2.1)
       zlib (~> 3.2)

--- a/lib/ephem/version.rb
+++ b/lib/ephem/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ephem
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
## [0.4.1] - 2025-08-03

### Improvements

* Exclude BSP files from release ([#42])

[#42]: https://github.com/rhannequin/ruby-ephem/pull/42

**Full Changelog**: https://github.com/rhannequin/ruby-ephem/compare/v0.4.0...v0.4.1
