### PR TITLE
Match SPICE last-loaded-wins precedence for overlapping segments

### DIFF
--- a/lib/ephem/segments/segment_group.rb
+++ b/lib/ephem/segments/segment_group.rb
@@ -74,7 +74,7 @@ module Ephem
       end
 
       def segment_for(tdb, tdb2)
-        @segments.find { |segment| segment.covers?(tdb, tdb2) } ||
+        @segments.reverse_each.find { |segment| segment.covers?(tdb, tdb2) } ||
           raise(OutOfRangeError.new(
             "Time #{tdb} is outside the coverage of this group", tdb
           ))


### PR DESCRIPTION
The 0.5.0 multi-segment time-split routing resolved a time to the **first**
matching segment (`@segments.find`). The pre-0.5.0 code built its segment
map with `to_h`, which for duplicate keys kept the **last** segment —
matching SPICE's last-loaded-takes-precedence rule.

This restores that behaviour by searching in reverse (`reverse_each.find`).
Real DE/PCK kernels split a body into contiguous, non-overlapping
intervals, so this is only observable at the edges of a genuine overlap,
but it keeps ephem consistent with SPICE and with the pre-0.5.0 semantics.

Found while auditing the new routing for the 0.5.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)